### PR TITLE
Add the coverage gem for tests & fix teams tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
 ruby '2.3.3'
-# Specify your gem's dependencies in create_api_gem.gemspec
+
+gem 'simplecov', group: :test
+
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,14 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 
+desc 'Start up the irb console with the gem required'
 task :console do
   exec 'irb -r create_api_gem -I ./lib'
 end
 
+desc 'Run the tests'
+task default: :test
+
 Rake::TestTask.new do |t|
   t.libs << 'test'
 end
-
-desc 'Run tests'
-task default: :test

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -1,3 +1,9 @@
+require 'simplecov'
+SimpleCov.start do
+  add_filter '/test/'
+end
+SimpleCov.command_name 'Gem Unit Tests'
+
 require 'minitest/autorun'
 require 'create_api_gem'
 

--- a/test/test_forms.rb
+++ b/test/test_forms.rb
@@ -1,6 +1,3 @@
-require 'minitest/autorun'
-require 'create_api_gem'
-
 class FormsTest < TestBase
   def test_all_requests
     form = Form.full_example

--- a/test/test_images.rb
+++ b/test/test_images.rb
@@ -1,6 +1,3 @@
-require 'minitest/autorun'
-require 'create_api_gem'
-
 class ImagesTest < TestBase
   def test_all_requests
     image = Image.full_example

--- a/test/test_teams.rb
+++ b/test/test_teams.rb
@@ -1,15 +1,15 @@
 require 'minitest/autorun'
 require 'create_api_gem'
 
-class WorkspacesTest < TestBase
+class TeamsTest < TestBase
   def test_all_requests
-    retrieve_team = RetreiveTeamRequest.new(token)
+    retrieve_team = RetrieveTeamRequest.new
     assert retrieve_team.success?, true
 
-    default_workspace = RetrieveAllWorkspacesRequest.execute(token).default_workspace
-    PatchWorkspaceRequest.execute(token, default_workspace, [PatchWorkspaceOperation.new(op: 'add', path: '/members', value: email)])
+    default_workspace = RetrieveAllWorkspacesRequest.execute.default_workspace
+    UpdateWorkspaceRequest.execute(default_workspace, [PatchWorkspaceOperation.new(op: 'add', path: '/members', value: email)])
 
-    update_team = UpdateTeamRequest.new(token, [PatchTeamOperation.new(op: 'remove', path: '/members', value: email)])
+    update_team = UpdateTeamRequest.new([PatchTeamOperation.new(op: 'remove', path: '/members', value: email)])
     assert update_team.success?, true
   end
 end

--- a/test/test_themes.rb
+++ b/test/test_themes.rb
@@ -1,6 +1,3 @@
-require 'minitest/autorun'
-require 'create_api_gem'
-
 class ThemesTest < TestBase
   def test_all_requests
     theme = Theme.full_example

--- a/test/test_workspaces.rb
+++ b/test/test_workspaces.rb
@@ -1,6 +1,3 @@
-require 'minitest/autorun'
-require 'create_api_gem'
-
 class WorkspacesTest < TestBase
   def test_all_requests
     workspace = Workspace.new


### PR DESCRIPTION
This PR adds the [simplecov](https://github.com/colszowka/simplecov) gem so we can get a coverage metric for the tests. We're currently on 94% 🎉  - you can see it on the bottom of the test output. It generates a HTML report which is currently under the `.gitignore` by default, we can change it. What do you think @sevki ?

Also this PR fixes the `TeamsTest` as before it was called `WorkspaceTest` and it was getting overridden by the actual `WorkspaceTest` and it wasn't being run, hence the class was out of date and the changes inside the tests needed to happen