### PR TITLE
Fix content-type headers

### DIFF
--- a/lib/create_api_gem/forms/requests/create_form_request.rb
+++ b/lib/create_api_gem/forms/requests/create_form_request.rb
@@ -23,7 +23,8 @@ class CreateFormRequest < FormRequest
       method: :post,
       url: "#{APIConfig.api_request_url}/forms",
       headers: {
-        'Authorization' => "Bearer #{token}"
+        'Authorization' => "Bearer #{token}",
+        'Content-Type' => 'application/json'
       },
       payload: form.payload
     )

--- a/lib/create_api_gem/forms/requests/messages/update_messages_request.rb
+++ b/lib/create_api_gem/forms/requests/messages/update_messages_request.rb
@@ -21,7 +21,8 @@ class UpdateMessagesRequest < APIRequest
       method: :put,
       url: "#{APIConfig.api_request_url}/forms/#{form.id}/messages",
       headers: {
-        'Authorization' => "Bearer #{token}"
+        'Authorization' => "Bearer #{token}",
+        'Content-Type' => 'application/json'
       },
       payload: messages.payload
     )

--- a/lib/create_api_gem/forms/requests/update_form_request.rb
+++ b/lib/create_api_gem/forms/requests/update_form_request.rb
@@ -23,7 +23,8 @@ class UpdateFormRequest < FormRequest
       method: :put,
       url: "#{APIConfig.api_request_url}/forms/#{form.id}",
       headers: {
-        'Authorization' => "Bearer #{token}"
+        'Authorization' => "Bearer #{token}",
+        'Content-Type' => 'application/json'
       },
       payload: form.payload
     )

--- a/lib/create_api_gem/images/requests/delete_image_request.rb
+++ b/lib/create_api_gem/images/requests/delete_image_request.rb
@@ -23,7 +23,6 @@ class DeleteImageRequest < ImageRequest
       method: :delete,
       url: "#{APIConfig.api_request_url}/images/#{image.id}",
       headers: {
-        'Content-Type' => 'application/json',
         'Authorization' => "Bearer #{token}"
       }
     )

--- a/lib/create_api_gem/images/requests/retrieve_all_images_request.rb
+++ b/lib/create_api_gem/images/requests/retrieve_all_images_request.rb
@@ -23,7 +23,6 @@ class RetrieveAllImagesRequest < ImageRequest
       method: :get,
       url: "#{APIConfig.api_request_url}/images",
       headers: {
-        'Content-Type' => 'application/json',
         'Authorization' => "Bearer #{token}"
       }
     )

--- a/lib/create_api_gem/images/requests/retrieve_frame_request.rb
+++ b/lib/create_api_gem/images/requests/retrieve_frame_request.rb
@@ -21,10 +21,7 @@ class RetrieveFrameRequest < ImageRequest
   def initialize(image, frame)
     request(
       method: :get,
-      url: "#{APIConfig.image_api_request_url}/images/#{image.id}/image/default-#{frame}frame.png",
-      headers: {
-        'Content-Type' => 'application/json'
-      }
+      url: "#{APIConfig.image_api_request_url}/images/#{image.id}/image/default-#{frame}frame.png"
     )
   end
 

--- a/lib/create_api_gem/images/requests/retrieve_image_request.rb
+++ b/lib/create_api_gem/images/requests/retrieve_image_request.rb
@@ -24,7 +24,7 @@ class RetrieveImageRequest < ImageRequest
           else
             "#{APIConfig.api_request_url}/images/#{image.id}/#{type}/#{size}"
           end
-    headers = { 'Content-Type' => 'application/json' }
+    headers = { }
     headers['Accept'] = 'application/json' if accept == 'json'
     request(
       method: :get,

--- a/lib/create_api_gem/teams/requests/update_team_request.rb
+++ b/lib/create_api_gem/teams/requests/update_team_request.rb
@@ -23,7 +23,8 @@ class UpdateTeamRequest < TeamRequest
       method: :patch,
       url: "#{APIConfig.api_request_url}/teams/mine",
       headers: {
-        'Authorization' => "Bearer #{token}"
+        'Authorization' => "Bearer #{token}",
+        'Content-Type' => 'application/json'
       },
       payload: operations.map(&:payload).to_json
     )

--- a/lib/create_api_gem/themes/requests/create_theme_request.rb
+++ b/lib/create_api_gem/themes/requests/create_theme_request.rb
@@ -23,7 +23,8 @@ class CreateThemeRequest < ThemeRequest
       method: :post,
       url: "#{APIConfig.api_request_url}/themes",
       headers: {
-        'Authorization' => "Bearer #{token}"
+        'Authorization' => "Bearer #{token}",
+        'Content-Type' => 'application/json'
       },
       payload: theme.payload
     )

--- a/lib/create_api_gem/themes/requests/update_theme_request.rb
+++ b/lib/create_api_gem/themes/requests/update_theme_request.rb
@@ -23,7 +23,8 @@ class UpdateThemeRequest < ThemeRequest
       method: :put,
       url: "#{APIConfig.api_request_url}/themes/#{theme.id}",
       headers: {
-        'Authorization' => "Bearer #{token}"
+        'Authorization' => "Bearer #{token}",
+        'Content-Type' => 'application/json'
       },
       payload: theme.payload
     )

--- a/lib/create_api_gem/workspaces/requests/delete_workspace_request.rb
+++ b/lib/create_api_gem/workspaces/requests/delete_workspace_request.rb
@@ -23,8 +23,7 @@ class DeleteWorkspaceRequest < WorkspaceRequest
       method: :delete,
       url: "#{APIConfig.workspaces_api_request_url}/#{workspace.id}",
       headers: {
-        'Authorization' => "Bearer #{token}",
-        'Content-Type' => 'application/json'
+        'Authorization' => "Bearer #{token}"
       }
     )
   end

--- a/lib/create_api_gem/workspaces/requests/retrieve_all_workspaces_request.rb
+++ b/lib/create_api_gem/workspaces/requests/retrieve_all_workspaces_request.rb
@@ -28,8 +28,7 @@ class RetrieveAllWorkspacesRequest < WorkspaceRequest
       method: :get,
       url: url,
       headers: {
-        'Authorization' => "Bearer #{token}",
-        'Content-Type' => 'application/json'
+        'Authorization' => "Bearer #{token}"
       }
     )
   end

--- a/lib/create_api_gem/workspaces/requests/retrieve_default_workspace_request.rb
+++ b/lib/create_api_gem/workspaces/requests/retrieve_default_workspace_request.rb
@@ -23,8 +23,7 @@ class RetrieveDefaultWorkspaceRequest < WorkspaceRequest
       method: :get,
       url: "#{APIConfig.workspaces_api_request_url}/default",
       headers: {
-        'Authorization' => "Bearer #{token}",
-        'Content-Type' => 'application/json'
+        'Authorization' => "Bearer #{token}"
       }
     )
   end

--- a/lib/create_api_gem/workspaces/requests/retrieve_workspace_request.rb
+++ b/lib/create_api_gem/workspaces/requests/retrieve_workspace_request.rb
@@ -23,8 +23,7 @@ class RetrieveWorkspaceRequest < WorkspaceRequest
       method: :get,
       url: "#{APIConfig.workspaces_api_request_url}/#{workspace.id}",
       headers: {
-        'Authorization' => "Bearer #{token}",
-        'Content-Type' => 'application/json'
+        'Authorization' => "Bearer #{token}"
       }
     )
   end


### PR DESCRIPTION
Remove content-type for GET requests, and add JSON as content-type for all requests with a body.

This has the effect of fixing all warning messages in the test suite.