### PR TITLE
Enclose all classes under a Typeform namespace

### DIFF
--- a/lib/create_api_gem/api_config.rb
+++ b/lib/create_api_gem/api_config.rb
@@ -15,20 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class APIConfig
-  def self.token
-    ENV['TYPEFORM_API_TOKEN']
-  end
+module Typeform
+  class APIConfig
+    def self.token
+      ENV['TYPEFORM_API_TOKEN']
+    end
 
-  def self.image_api_request_url
-    'https://images.typeform.com'
-  end
+    def self.image_api_request_url
+      'https://images.typeform.com'
+    end
 
-  def self.workspaces_api_request_url
-    'https://api.typeform.com/workspaces'
-  end
+    def self.workspaces_api_request_url
+      'https://api.typeform.com/workspaces'
+    end
 
-  def self.api_request_url
-    'https://api.typeform.com'
+    def self.api_request_url
+      'https://api.typeform.com'
+    end
   end
 end

--- a/lib/create_api_gem/api_request.rb
+++ b/lib/create_api_gem/api_request.rb
@@ -15,63 +15,65 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class APIRequest
-  def self.execute(*args)
-    new(*args).tap do |request|
-      raise StandardError, 'Failed asserting that the request succeeds' unless request.success?
+module Typeform
+  class APIRequest
+    def self.execute(*args)
+      new(*args).tap do |request|
+        raise StandardError, 'Failed asserting that the request succeeds' unless request.success?
+      end
     end
-  end
 
-  def headers
-    @response.headers
-  end
+    def headers
+      @response.headers
+    end
 
-  def inspect
-    "#{@response.code}\n#{@response}"
-  end
+    def inspect
+      "#{@response.code}\n#{@response}"
+    end
 
-  def bad_request?
-    @response.code == 400
-  end
+    def bad_request?
+      @response.code == 400
+    end
 
-  def unauthorized?
-    @response.code == 401
-  end
+    def unauthorized?
+      @response.code == 401
+    end
 
-  def payment_required?
-    @response.code == 402
-  end
+    def payment_required?
+      @response.code == 402
+    end
 
-  def forbidden?
-    @response.code == 403
-  end
+    def forbidden?
+      @response.code == 403
+    end
 
-  def not_found?
-    @response.code == 404
-  end
+    def not_found?
+      @response.code == 404
+    end
 
-  def service_unavailable?
-    @response.code == 502 || @response.code == 503
-  end
+    def service_unavailable?
+      @response.code == 502 || @response.code == 503
+    end
 
-  def error_code
-    json.fetch(:code)
-  end
+    def error_code
+      json.fetch(:code)
+    end
 
-  private
+    private
 
-  def request(args = {})
-    RestClient::Request.execute(args) { |r| @response = r }
-  end
+    def request(args = {})
+      RestClient::Request.execute(args) { |r| @response = r }
+    end
 
-  def json
-    JSON.parse(@response, symbolize_names: true)
-  end
+    def json
+      JSON.parse(@response, symbolize_names: true)
+    end
 
-  def json?
-    json
-    true
-  rescue JSON::ParserError
-    false
+    def json?
+      json
+      true
+    rescue JSON::ParserError
+      false
+    end
   end
 end

--- a/lib/create_api_gem/data_generator.rb
+++ b/lib/create_api_gem/data_generator.rb
@@ -17,28 +17,30 @@
 
 require 'ffaker'
 
-module DataGenerator
-  def self.title
-    FFaker::Movie.title
-  end
+module Typeform
+  module DataGenerator
+    def self.title
+      FFaker::Movie.title
+    end
 
-  def self.description
-    FFaker::Lorem.paragraph
-  end
+    def self.description
+      FFaker::Lorem.paragraph
+    end
 
-  def self.email
-    FFaker::Internet.email
-  end
+    def self.email
+      FFaker::Internet.email
+    end
 
-  def self.color_code
-    '#' + SecureRandom.hex(3)
-  end
+    def self.color_code
+      '#' + SecureRandom.hex(3)
+    end
 
-  def self.field_ref
-    SecureRandom.hex(6)
-  end
+    def self.field_ref
+      SecureRandom.hex(6)
+    end
 
-  def self.uuid
-    SecureRandom.uuid
+    def self.uuid
+      SecureRandom.uuid
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/block.rb
+++ b/lib/create_api_gem/forms/blocks/block.rb
@@ -15,81 +15,83 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class Block
-  def self.all_types
-    {
-      'date block' => DateBlock,
-      'dropdown block' => DropdownBlock,
-      'email block' => EmailBlock,
-      'file upload block' => FileUploadBlock,
-      'group block' => GroupBlock,
-      'legal block' => LegalBlock,
-      'long text block' => LongTextBlock,
-      'multiple choice block' => MultipleChoiceBlock,
-      'number block' => NumberBlock,
-      'opinion scale block' => OpinionScaleBlock,
-      'payment block' => PaymentBlock,
-      'picture choice block' => PictureChoiceBlock,
-      'rating block' => RatingBlock,
-      'short text block' => ShortTextBlock,
-      'statement block' => StatementBlock,
-      'website block' => WebsiteBlock,
-      'yes no block' => YesNoBlock,
-      'phone number block' => PhoneNumberBlock
-    }
-  end
-
-  def self.from_response(response)
-    response[:type] = response[:type].to_sym
-    if response[:type] == :group
-      response[:properties][:fields].map! { |field| Block.from_response(field) } unless response[:properties][:fields].nil?
+module Typeform
+  class Block
+    def self.all_types
+      {
+        'date block' => DateBlock,
+        'dropdown block' => DropdownBlock,
+        'email block' => EmailBlock,
+        'file upload block' => FileUploadBlock,
+        'group block' => GroupBlock,
+        'legal block' => LegalBlock,
+        'long text block' => LongTextBlock,
+        'multiple choice block' => MultipleChoiceBlock,
+        'number block' => NumberBlock,
+        'opinion scale block' => OpinionScaleBlock,
+        'payment block' => PaymentBlock,
+        'picture choice block' => PictureChoiceBlock,
+        'rating block' => RatingBlock,
+        'short text block' => ShortTextBlock,
+        'statement block' => StatementBlock,
+        'website block' => WebsiteBlock,
+        'yes no block' => YesNoBlock,
+        'phone number block' => PhoneNumberBlock
+      }
     end
-    properties = response[:properties] || {}
-    validations = response[:validations] || {}
-    block_params = response.keep_if { |k, _| k != :properties && k != :validations } || {}
-    params = properties.merge(validations).merge(block_params)
-    all_types.fetch(block_symbol_to_string(response[:type])).new(params)
-  end
 
-  def same?(actual)
-    (id.nil? || id == actual.id) &&
-      type == actual.type &&
-      title == actual.title &&
-      (ref.nil? || ref == actual.ref) &&
-      (description.nil? || description == actual.description) &&
-      (respond_to?(:attachment) ? same_attachment?(actual.attachment) : true) &&
-      same_extra_attributes?(actual)
-  end
-
-  def same_attachment?(actual_attachment)
-    return true if attachment.nil?
-
-    type = attachment[:type]
-    case type
-    when 'image'
-      return (attachment[:href].start_with?("#{APIConfig.image_api_request_url}/images/") && actual_attachment[:href].start_with?("#{APIConfig.image_api_request_url}/images/"))
-    when 'video'
-      return attachment == actual_attachment
-    else
-      return false
+    def self.from_response(response)
+      response[:type] = response[:type].to_sym
+      if response[:type] == :group
+        response[:properties][:fields].map! { |field| Block.from_response(field) } unless response[:properties][:fields].nil?
+      end
+      properties = response[:properties] || {}
+      validations = response[:validations] || {}
+      block_params = response.keep_if { |k, _| k != :properties && k != :validations } || {}
+      params = properties.merge(validations).merge(block_params)
+      all_types.fetch(block_symbol_to_string(response[:type])).new(params)
     end
-  end
 
-  def self.attachment
-    [Block.image_attachment_payload, Block.video_attachment_payload].sample
-  end
+    def same?(actual)
+      (id.nil? || id == actual.id) &&
+        type == actual.type &&
+        title == actual.title &&
+        (ref.nil? || ref == actual.ref) &&
+        (description.nil? || description == actual.description) &&
+        (respond_to?(:attachment) ? same_attachment?(actual.attachment) : true) &&
+        same_extra_attributes?(actual)
+    end
 
-  def self.image_attachment_payload(image_id: 'default')
-    { type: 'image', href: "#{APIConfig.image_api_request_url}/images/#{image_id}" }
-  end
+    def same_attachment?(actual_attachment)
+      return true if attachment.nil?
 
-  def self.video_attachment_payload(video_url: 'https://www.youtube.com/watch?v=Uui3oT-XBxs', scale: 0.6)
-    { type: 'video', href: video_url, scale: scale }
-  end
+      type = attachment[:type]
+      case type
+      when 'image'
+        return (attachment[:href].start_with?("#{APIConfig.image_api_request_url}/images/") && actual_attachment[:href].start_with?("#{APIConfig.image_api_request_url}/images/"))
+      when 'video'
+        return attachment == actual_attachment
+      else
+        return false
+      end
+    end
 
-  def self.block_symbol_to_string(symbol)
-    string = symbol.to_s
-    string.sub!('_', ' ')
-    string + ' block'
+    def self.attachment
+      [Block.image_attachment_payload, Block.video_attachment_payload].sample
+    end
+
+    def self.image_attachment_payload(image_id: 'default')
+      { type: 'image', href: "#{APIConfig.image_api_request_url}/images/#{image_id}" }
+    end
+
+    def self.video_attachment_payload(video_url: 'https://www.youtube.com/watch?v=Uui3oT-XBxs', scale: 0.6)
+      { type: 'video', href: video_url, scale: scale }
+    end
+
+    def self.block_symbol_to_string(symbol)
+      string = symbol.to_s
+      string.sub!('_', ' ')
+      string + ' block'
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/date_block.rb
+++ b/lib/create_api_gem/forms/blocks/date_block.rb
@@ -17,65 +17,67 @@
 
 require_relative 'block'
 
-class DateBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :structure, :separator, :required, :attachment
+module Typeform
+  class DateBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :structure, :separator, :required, :attachment
 
-  def initialize(id: nil, title: nil, type: :date, ref: nil, description: nil, structure: nil,
-                 separator: nil, required: nil, attachment: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @structure = structure
-    @separator = separator
-    @required = required
-    @attachment = attachment
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:id] = id unless id.nil?
-    payload[:ref] = ref unless ref.nil?
-    unless description.nil? && structure.nil? && separator.nil?
-      payload[:properties] = {}
-      payload[:properties][:description] = description unless description.nil?
-      payload[:properties][:structure] = structure unless structure.nil?
-      payload[:properties][:separator] = separator unless separator.nil?
+    def initialize(id: nil, title: nil, type: :date, ref: nil, description: nil, structure: nil,
+                  separator: nil, required: nil, attachment: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @structure = structure
+      @separator = separator
+      @required = required
+      @attachment = attachment
     end
-    unless required.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required
+
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:id] = id unless id.nil?
+      payload[:ref] = ref unless ref.nil?
+      unless description.nil? && structure.nil? && separator.nil?
+        payload[:properties] = {}
+        payload[:properties][:description] = description unless description.nil?
+        payload[:properties][:structure] = structure unless structure.nil?
+        payload[:properties][:separator] = separator unless separator.nil?
+      end
+      unless required.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required
+      end
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
     end
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    (structure.nil? ? DateBlock.default.structure : structure) == actual.structure &&
-      (separator.nil? ? DateBlock.default.separator : separator) == actual.separator &&
-      (required.nil? ? DateBlock.default.required : required) == actual.required
-  end
+    def same_extra_attributes?(actual)
+      (structure.nil? ? DateBlock.default.structure : structure) == actual.structure &&
+        (separator.nil? ? DateBlock.default.separator : separator) == actual.separator &&
+        (required.nil? ? DateBlock.default.required : required) == actual.required
+    end
 
-  def self.default
-    DateBlock.new(
-      structure: 'MMDDYYYY',
-      separator: '/',
-      required: false
-    )
-  end
+    def self.default
+      DateBlock.new(
+        structure: 'MMDDYYYY',
+        separator: '/',
+        required: false
+      )
+    end
 
-  def self.full_example(id: nil)
-    DateBlock.new(
-      ref: DataGenerator.field_ref,
-      separator: '-',
-      structure: 'DDMMYYYY',
-      required: true,
-      id: id,
-      description: DataGenerator.description,
-      attachment: Block.attachment
-    )
+    def self.full_example(id: nil)
+      DateBlock.new(
+        ref: DataGenerator.field_ref,
+        separator: '-',
+        structure: 'DDMMYYYY',
+        required: true,
+        id: id,
+        description: DataGenerator.description,
+        attachment: Block.attachment
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/dropdown_block.rb
+++ b/lib/create_api_gem/forms/blocks/dropdown_block.rb
@@ -17,77 +17,79 @@
 
 require_relative 'block'
 
-class DropdownBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :alphabetical_order, :choices, :required, :attachment
+module Typeform
+  class DropdownBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :alphabetical_order, :choices, :required, :attachment
 
-  def initialize(id: nil, title: nil, type: :dropdown, ref: nil, description: nil, alphabetical_order: nil,
-                 choices: nil, required: nil, attachment: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @alphabetical_order = alphabetical_order
-    @choices = choices || DropdownBlock.choices
-    @required = required
-    @attachment = attachment
-  end
-
-  def self.choices
-    [
-      { label: 'choice 1' },
-      { label: 'choice 2' }
-    ]
-  end
-
-  def payload
-    payload = {}
-    payload[:properties] = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:ref] = ref unless ref.nil?
-    payload[:id] = id unless id.nil?
-    payload[:properties][:choices] = choices
-    payload[:properties][:description] = description unless description.nil?
-    payload[:properties][:alphabetical_order] = alphabetical_order unless alphabetical_order.nil?
-    unless required.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required
+    def initialize(id: nil, title: nil, type: :dropdown, ref: nil, description: nil, alphabetical_order: nil,
+                  choices: nil, required: nil, attachment: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @alphabetical_order = alphabetical_order
+      @choices = choices || DropdownBlock.choices
+      @required = required
+      @attachment = attachment
     end
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    same_choices?(actual.choices) &&
-      (alphabetical_order.nil? ? DropdownBlock.default.alphabetical_order : alphabetical_order) == actual.alphabetical_order &&
-      (required.nil? ? DropdownBlock.default.required : required) == actual.required
-  end
-
-  def same_choices?(actual_choices)
-    choices.zip(actual_choices).all? do |expected, actual|
-      (!expected.key?(:id) || expected[id] == actual[id]) &&
-        expected[:label] == actual[:label]
+    def self.choices
+      [
+        { label: 'choice 1' },
+        { label: 'choice 2' }
+      ]
     end
-  end
 
-  def self.default
-    DropdownBlock.new(
-      choices: choices,
-      alphabetical_order: false,
-      required: false
-    )
-  end
+    def payload
+      payload = {}
+      payload[:properties] = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:ref] = ref unless ref.nil?
+      payload[:id] = id unless id.nil?
+      payload[:properties][:choices] = choices
+      payload[:properties][:description] = description unless description.nil?
+      payload[:properties][:alphabetical_order] = alphabetical_order unless alphabetical_order.nil?
+      unless required.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required
+      end
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
+    end
 
-  def self.full_example(id: nil)
-    DropdownBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      id: id,
-      choices: choices,
-      alphabetical_order: true,
-      required: true,
-      attachment: Block.attachment
-    )
+    def same_extra_attributes?(actual)
+      same_choices?(actual.choices) &&
+        (alphabetical_order.nil? ? DropdownBlock.default.alphabetical_order : alphabetical_order) == actual.alphabetical_order &&
+        (required.nil? ? DropdownBlock.default.required : required) == actual.required
+    end
+
+    def same_choices?(actual_choices)
+      choices.zip(actual_choices).all? do |expected, actual|
+        (!expected.key?(:id) || expected[id] == actual[id]) &&
+          expected[:label] == actual[:label]
+      end
+    end
+
+    def self.default
+      DropdownBlock.new(
+        choices: choices,
+        alphabetical_order: false,
+        required: false
+      )
+    end
+
+    def self.full_example(id: nil)
+      DropdownBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        id: id,
+        choices: choices,
+        alphabetical_order: true,
+        required: true,
+        attachment: Block.attachment
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/email_block.rb
+++ b/lib/create_api_gem/forms/blocks/email_block.rb
@@ -17,54 +17,56 @@
 
 require_relative 'block'
 
-class EmailBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :required, :attachment
+module Typeform
+  class EmailBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :required, :attachment
 
-  def initialize(id: nil, title: nil, type: :email, ref: nil, description: nil, required: nil, attachment: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @required = required
-    @attachment = attachment
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:id] = id unless id.nil?
-    payload[:ref] = ref unless ref.nil?
-    unless description.nil?
-      payload[:properties] = {}
-      payload[:properties][:description] = description
+    def initialize(id: nil, title: nil, type: :email, ref: nil, description: nil, required: nil, attachment: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @required = required
+      @attachment = attachment
     end
-    unless required.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required
+
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:id] = id unless id.nil?
+      payload[:ref] = ref unless ref.nil?
+      unless description.nil?
+        payload[:properties] = {}
+        payload[:properties][:description] = description
+      end
+      unless required.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required
+      end
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
     end
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    (required.nil? ? EmailBlock.default.required : required) == actual.required
-  end
+    def same_extra_attributes?(actual)
+      (required.nil? ? EmailBlock.default.required : required) == actual.required
+    end
 
-  def self.default
-    EmailBlock.new(
-      required: false
-    )
-  end
+    def self.default
+      EmailBlock.new(
+        required: false
+      )
+    end
 
-  def self.full_example(id: nil)
-    EmailBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      id: id,
-      required: true,
-      attachment: Block.attachment
-    )
+    def self.full_example(id: nil)
+      EmailBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        id: id,
+        required: true,
+        attachment: Block.attachment
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/file_upload_block.rb
+++ b/lib/create_api_gem/forms/blocks/file_upload_block.rb
@@ -17,51 +17,53 @@
 
 require_relative 'block'
 
-class FileUploadBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :required
+module Typeform
+  class FileUploadBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :required
 
-  def initialize(id: nil, title: nil, type: :file_upload, ref: nil, description: nil, required: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @required = required
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:id] = id unless id.nil?
-    payload[:ref] = ref unless ref.nil?
-    unless description.nil?
-      payload[:properties] = {}
-      payload[:properties][:description] = description
+    def initialize(id: nil, title: nil, type: :file_upload, ref: nil, description: nil, required: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @required = required
     end
-    unless required.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required
+
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:id] = id unless id.nil?
+      payload[:ref] = ref unless ref.nil?
+      unless description.nil?
+        payload[:properties] = {}
+        payload[:properties][:description] = description
+      end
+      unless required.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required
+      end
+      payload
     end
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    (required.nil? ? FileUploadBlock.default.required : required) == actual.required
-  end
+    def same_extra_attributes?(actual)
+      (required.nil? ? FileUploadBlock.default.required : required) == actual.required
+    end
 
-  def self.default
-    FileUploadBlock.new(
-      required: false
-    )
-  end
+    def self.default
+      FileUploadBlock.new(
+        required: false
+      )
+    end
 
-  def self.full_example(id: nil)
-    FileUploadBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      required: true,
-      id: id
-    )
+    def self.full_example(id: nil)
+      FileUploadBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        required: true,
+        id: id
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/group_block.rb
+++ b/lib/create_api_gem/forms/blocks/group_block.rb
@@ -17,78 +17,80 @@
 
 require_relative 'block'
 
-class GroupBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :show_button, :button_text, :attachment, :fields
+module Typeform
+  class GroupBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :show_button, :button_text, :attachment, :fields
 
-  def initialize(id: nil, title: nil, type: :group, ref: nil, description: nil, show_button: nil, button_text: nil, attachment: nil, fields: [])
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @show_button = show_button
-    @button_text = button_text
-    @attachment = attachment
-    @fields = fields
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:id] = id unless id.nil?
-    payload[:ref] = ref unless ref.nil?
-    unless description.nil? && fields.nil? && show_button.nil? && button_text.nil?
-      payload[:properties] = {}
-      payload[:properties][:description] = description unless description.nil?
-      payload[:properties][:show_button] = show_button unless show_button.nil?
-      payload[:properties][:button_text] = button_text unless button_text.nil?
-      unless fields.nil?
-        p = []
-        fields.each { |field| p << field.payload unless field.nil? }
-        payload[:properties][:fields] = p
-      end
+    def initialize(id: nil, title: nil, type: :group, ref: nil, description: nil, show_button: nil, button_text: nil, attachment: nil, fields: [])
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @show_button = show_button
+      @button_text = button_text
+      @attachment = attachment
+      @fields = fields
     end
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    same_fields?(actual.fields)
-  end
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:id] = id unless id.nil?
+      payload[:ref] = ref unless ref.nil?
+      unless description.nil? && fields.nil? && show_button.nil? && button_text.nil?
+        payload[:properties] = {}
+        payload[:properties][:description] = description unless description.nil?
+        payload[:properties][:show_button] = show_button unless show_button.nil?
+        payload[:properties][:button_text] = button_text unless button_text.nil?
+        unless fields.nil?
+          p = []
+          fields.each { |field| p << field.payload unless field.nil? }
+          payload[:properties][:fields] = p
+        end
+      end
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
+    end
 
-  def same_fields?(actual_fields)
-    fields.zip(actual_fields).all? do |expected, actual|
-      expected.same?(actual)
-    end && fields.length == actual_fields.length
-  end
+    def same_extra_attributes?(actual)
+      same_fields?(actual.fields)
+    end
 
-  def self.default
-    GroupBlock.new(
-      fields: [],
-      button_text: 'Continue',
-      show_button: false
-    )
-  end
+    def same_fields?(actual_fields)
+      fields.zip(actual_fields).all? do |expected, actual|
+        expected.same?(actual)
+      end && fields.length == actual_fields.length
+    end
 
-  def self.full_example(id: nil, blocks: nil)
-    fields = if blocks.nil?
-               Block.all_types.values.map do |block|
-                 block.full_example unless [GroupBlock, PaymentBlock].include?(block)
+    def self.default
+      GroupBlock.new(
+        fields: [],
+        button_text: 'Continue',
+        show_button: false
+      )
+    end
+
+    def self.full_example(id: nil, blocks: nil)
+      fields = if blocks.nil?
+                 Block.all_types.values.map do |block|
+                   block.full_example unless [GroupBlock, PaymentBlock].include?(block)
+                 end
+               else
+                 blocks.map do |block|
+                   block.class.full_example(id: block.id) unless [GroupBlock, PaymentBlock].include?(block)
+                 end
                end
-             else
-               blocks.map do |block|
-                 block.class.full_example(id: block.id) unless [GroupBlock, PaymentBlock].include?(block)
-               end
-             end
-    GroupBlock.new(
-      ref: DataGenerator.field_ref,
-      id: id,
-      description: DataGenerator.description,
-      button_text: 'Click me!',
-      show_button: true,
-      fields: fields.compact,
-      attachment: Block.attachment
-    )
+      GroupBlock.new(
+        ref: DataGenerator.field_ref,
+        id: id,
+        description: DataGenerator.description,
+        button_text: 'Click me!',
+        show_button: true,
+        fields: fields.compact,
+        attachment: Block.attachment
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/legal_block.rb
+++ b/lib/create_api_gem/forms/blocks/legal_block.rb
@@ -17,51 +17,53 @@
 
 require_relative 'block'
 
-class LegalBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :required
+module Typeform
+  class LegalBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :required
 
-  def initialize(id: nil, title: nil, type: :legal, ref: nil, description: nil, required: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @required = required
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:id] = id unless id.nil?
-    payload[:ref] = ref unless ref.nil?
-    unless description.nil?
-      payload[:properties] = {}
-      payload[:properties][:description] = description
+    def initialize(id: nil, title: nil, type: :legal, ref: nil, description: nil, required: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @required = required
     end
-    unless required.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required
+
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:id] = id unless id.nil?
+      payload[:ref] = ref unless ref.nil?
+      unless description.nil?
+        payload[:properties] = {}
+        payload[:properties][:description] = description
+      end
+      unless required.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required
+      end
+      payload
     end
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    (required.nil? ? LegalBlock.default.required : required) == actual.required
-  end
+    def same_extra_attributes?(actual)
+      (required.nil? ? LegalBlock.default.required : required) == actual.required
+    end
 
-  def self.default
-    LegalBlock.new(
-      required: false
-    )
-  end
+    def self.default
+      LegalBlock.new(
+        required: false
+      )
+    end
 
-  def self.full_example(id: nil)
-    LegalBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      required: true,
-      id: id
-    )
+    def self.full_example(id: nil)
+      LegalBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        required: true,
+        id: id
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/long_text_block.rb
+++ b/lib/create_api_gem/forms/blocks/long_text_block.rb
@@ -17,59 +17,61 @@
 
 require_relative 'block'
 
-class LongTextBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :required, :max_length, :attachment
+module Typeform
+  class LongTextBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :required, :max_length, :attachment
 
-  def initialize(id: nil, title: nil, type: :long_text, ref: nil, description: nil, required: nil,
-                 max_length: nil, attachment: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @required = required
-    @max_length = max_length
-    @attachment = attachment
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:id] = id unless id.nil?
-    payload[:ref] = ref unless ref.nil?
-    unless description.nil?
-      payload[:properties] = {}
-      payload[:properties][:description] = description
+    def initialize(id: nil, title: nil, type: :long_text, ref: nil, description: nil, required: nil,
+                  max_length: nil, attachment: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @required = required
+      @max_length = max_length
+      @attachment = attachment
     end
-    unless required.nil? && max_length.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required unless required.nil?
-      payload[:validations][:max_length] = max_length unless max_length.nil?
+
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:id] = id unless id.nil?
+      payload[:ref] = ref unless ref.nil?
+      unless description.nil?
+        payload[:properties] = {}
+        payload[:properties][:description] = description
+      end
+      unless required.nil? && max_length.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required unless required.nil?
+        payload[:validations][:max_length] = max_length unless max_length.nil?
+      end
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
     end
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    (max_length.nil? || max_length == actual.max_length) &&
-      (required.nil? ? LongTextBlock.default.required : required) == actual.required
-  end
+    def same_extra_attributes?(actual)
+      (max_length.nil? || max_length == actual.max_length) &&
+        (required.nil? ? LongTextBlock.default.required : required) == actual.required
+    end
 
-  def self.default
-    LongTextBlock.new(
-      required: false
-    )
-  end
+    def self.default
+      LongTextBlock.new(
+        required: false
+      )
+    end
 
-  def self.full_example(id: nil)
-    LongTextBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      id: id,
-      required: true,
-      max_length: 500,
-      attachment: Block.attachment
-    )
+    def self.full_example(id: nil)
+      LongTextBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        id: id,
+        required: true,
+        max_length: 500,
+        attachment: Block.attachment
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/multiple_choice_block.rb
+++ b/lib/create_api_gem/forms/blocks/multiple_choice_block.rb
@@ -17,101 +17,103 @@
 
 require_relative 'block'
 
-class MultipleChoiceBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :randomize, :allow_multiple_selection, :allow_other_choice,
-                :vertical_alignment, :choices, :required, :attachment
+module Typeform
+  class MultipleChoiceBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :randomize, :allow_multiple_selection, :allow_other_choice,
+                  :vertical_alignment, :choices, :required, :attachment
 
-  def initialize(id: nil, title: nil, type: :multiple_choice, ref: nil, description: nil, randomize: nil,
-                 allow_multiple_selection: nil, allow_other_choice: nil, vertical_alignment: nil,
-                 choices: nil, required: nil, attachment: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @randomize = randomize
-    @allow_multiple_selection = allow_multiple_selection
-    @allow_other_choice = allow_other_choice
-    @vertical_alignment = vertical_alignment
-    @choices = choices || MultipleChoiceBlock.choices
-    @required = required
-    @attachment = attachment
-  end
-
-  def self.choices
-    [
-      {
-        label: 'choice 1',
-        ref: DataGenerator.field_ref
-      },
-      {
-        label: 'choice 2',
-        ref: DataGenerator.field_ref
-      }
-    ]
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:ref] = ref unless ref.nil?
-    payload[:id] = id unless id.nil?
-    payload[:properties] = {}
-    payload[:properties][:choices] = choices
-    payload[:properties][:description] = description unless description.nil?
-    payload[:properties][:randomize] = randomize unless randomize.nil?
-    payload[:properties][:allow_multiple_selection] = allow_multiple_selection unless allow_multiple_selection.nil?
-    payload[:properties][:allow_other_choice] = allow_other_choice unless allow_other_choice.nil?
-    payload[:properties][:vertical_alignment] = vertical_alignment unless vertical_alignment.nil?
-    unless required.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required
+    def initialize(id: nil, title: nil, type: :multiple_choice, ref: nil, description: nil, randomize: nil,
+                  allow_multiple_selection: nil, allow_other_choice: nil, vertical_alignment: nil,
+                  choices: nil, required: nil, attachment: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @randomize = randomize
+      @allow_multiple_selection = allow_multiple_selection
+      @allow_other_choice = allow_other_choice
+      @vertical_alignment = vertical_alignment
+      @choices = choices || MultipleChoiceBlock.choices
+      @required = required
+      @attachment = attachment
     end
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    same_choices?(actual.choices) &&
-      (randomize.nil? ? MultipleChoiceBlock.default.randomize : randomize) == actual.randomize &&
-      (allow_multiple_selection.nil? ? MultipleChoiceBlock.default.allow_multiple_selection : allow_multiple_selection) == actual.allow_multiple_selection &&
-      (allow_other_choice.nil? ? MultipleChoiceBlock.default.allow_other_choice : allow_other_choice) == actual.allow_other_choice &&
-      (vertical_alignment.nil? ? MultipleChoiceBlock.default.vertical_alignment : vertical_alignment) == actual.vertical_alignment &&
-      (required.nil? ? MultipleChoiceBlock.default.required : required) == actual.required
-  end
-
-  def same_choices?(actual_choices)
-    choices.zip(actual_choices).all? do |expected, actual|
-      (!expected.key?(:id) || expected[:id] == actual[:id]) &&
-        (!expected.key?(:ref) || expected[:ref] == actual[:ref]) &&
-        expected[:label] == actual[:label]
+    def self.choices
+      [
+        {
+          label: 'choice 1',
+          ref: DataGenerator.field_ref
+        },
+        {
+          label: 'choice 2',
+          ref: DataGenerator.field_ref
+        }
+      ]
     end
-  end
 
-  def self.default
-    MultipleChoiceBlock.new(
-      choices: choices,
-      randomize: false,
-      allow_multiple_selection: false,
-      allow_other_choice: false,
-      vertical_alignment: true,
-      required: false
-    )
-  end
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:ref] = ref unless ref.nil?
+      payload[:id] = id unless id.nil?
+      payload[:properties] = {}
+      payload[:properties][:choices] = choices
+      payload[:properties][:description] = description unless description.nil?
+      payload[:properties][:randomize] = randomize unless randomize.nil?
+      payload[:properties][:allow_multiple_selection] = allow_multiple_selection unless allow_multiple_selection.nil?
+      payload[:properties][:allow_other_choice] = allow_other_choice unless allow_other_choice.nil?
+      payload[:properties][:vertical_alignment] = vertical_alignment unless vertical_alignment.nil?
+      unless required.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required
+      end
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
+    end
 
-  def self.full_example(id: nil)
-    MultipleChoiceBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      id: id,
-      randomize: true,
-      allow_multiple_selection: true,
-      allow_other_choice: true,
-      vertical_alignment: true,
-      choices: choices,
-      required: true,
-      attachment: Block.attachment
-    )
+    def same_extra_attributes?(actual)
+      same_choices?(actual.choices) &&
+        (randomize.nil? ? MultipleChoiceBlock.default.randomize : randomize) == actual.randomize &&
+        (allow_multiple_selection.nil? ? MultipleChoiceBlock.default.allow_multiple_selection : allow_multiple_selection) == actual.allow_multiple_selection &&
+        (allow_other_choice.nil? ? MultipleChoiceBlock.default.allow_other_choice : allow_other_choice) == actual.allow_other_choice &&
+        (vertical_alignment.nil? ? MultipleChoiceBlock.default.vertical_alignment : vertical_alignment) == actual.vertical_alignment &&
+        (required.nil? ? MultipleChoiceBlock.default.required : required) == actual.required
+    end
+
+    def same_choices?(actual_choices)
+      choices.zip(actual_choices).all? do |expected, actual|
+        (!expected.key?(:id) || expected[:id] == actual[:id]) &&
+          (!expected.key?(:ref) || expected[:ref] == actual[:ref]) &&
+          expected[:label] == actual[:label]
+      end
+    end
+
+    def self.default
+      MultipleChoiceBlock.new(
+        choices: choices,
+        randomize: false,
+        allow_multiple_selection: false,
+        allow_other_choice: false,
+        vertical_alignment: true,
+        required: false
+      )
+    end
+
+    def self.full_example(id: nil)
+      MultipleChoiceBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        id: id,
+        randomize: true,
+        allow_multiple_selection: true,
+        allow_other_choice: true,
+        vertical_alignment: true,
+        choices: choices,
+        required: true,
+        attachment: Block.attachment
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/number_block.rb
+++ b/lib/create_api_gem/forms/blocks/number_block.rb
@@ -17,63 +17,65 @@
 
 require_relative 'block'
 
-class NumberBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :required, :min_value, :max_value, :attachment
+module Typeform
+  class NumberBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :required, :min_value, :max_value, :attachment
 
-  def initialize(id: nil, title: nil, type: :number, ref: nil, description: nil, required: nil, min_value: nil,
-                 max_value: nil, attachment: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @required = required
-    @min_value = min_value
-    @max_value = max_value
-    @attachment = attachment
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:ref] = ref unless ref.nil?
-    payload[:id] = id unless id.nil?
-    unless description.nil?
-      payload[:properties] = {}
-      payload[:properties][:description] = description
+    def initialize(id: nil, title: nil, type: :number, ref: nil, description: nil, required: nil, min_value: nil,
+                  max_value: nil, attachment: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @required = required
+      @min_value = min_value
+      @max_value = max_value
+      @attachment = attachment
     end
-    unless required.nil? && min_value.nil? && max_value.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required unless required.nil?
-      payload[:validations][:min_value] = min_value unless min_value.nil?
-      payload[:validations][:max_value] = max_value unless max_value.nil?
+
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:ref] = ref unless ref.nil?
+      payload[:id] = id unless id.nil?
+      unless description.nil?
+        payload[:properties] = {}
+        payload[:properties][:description] = description
+      end
+      unless required.nil? && min_value.nil? && max_value.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required unless required.nil?
+        payload[:validations][:min_value] = min_value unless min_value.nil?
+        payload[:validations][:max_value] = max_value unless max_value.nil?
+      end
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
     end
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    (min_value.nil? || min_value == actual.min_value) &&
-      (max_value.nil? || max_value == actual.max_value) &&
-      (required.nil? ? NumberBlock.default.required : required) == actual.required
-  end
+    def same_extra_attributes?(actual)
+      (min_value.nil? || min_value == actual.min_value) &&
+        (max_value.nil? || max_value == actual.max_value) &&
+        (required.nil? ? NumberBlock.default.required : required) == actual.required
+    end
 
-  def self.default
-    NumberBlock.new(
-      required: false
-    )
-  end
+    def self.default
+      NumberBlock.new(
+        required: false
+      )
+    end
 
-  def self.full_example(id: nil)
-    NumberBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      id: id,
-      required: true,
-      min_value: 1,
-      max_value: 500,
-      attachment: Block.attachment
-    )
+    def self.full_example(id: nil)
+      NumberBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        id: id,
+        required: true,
+        min_value: 1,
+        max_value: 500,
+        attachment: Block.attachment
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/opinion_scale_block.rb
+++ b/lib/create_api_gem/forms/blocks/opinion_scale_block.rb
@@ -17,69 +17,71 @@
 
 require_relative 'block'
 
-class OpinionScaleBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :steps, :start_at_one, :labels, :required, :attachment
+module Typeform
+  class OpinionScaleBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :steps, :start_at_one, :labels, :required, :attachment
 
-  def initialize(id: nil, title: nil, type: :opinion_scale, ref: nil, description: nil, steps: nil, start_at_one: nil,
-                 labels: nil, required: nil, attachment: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @steps = steps
-    @start_at_one = start_at_one
-    @labels = labels
-    @required = required
-    @attachment = attachment
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:id] = id unless id.nil?
-    payload[:ref] = ref unless ref.nil?
-    unless description.nil? && steps.nil? && start_at_one.nil? && labels.nil?
-      payload[:properties] = {}
-      payload[:properties][:description] = description unless description.nil?
-      payload[:properties][:steps] = steps unless steps.nil?
-      payload[:properties][:start_at_one] = start_at_one unless start_at_one.nil?
-      payload[:properties][:labels] = labels unless labels.nil?
+    def initialize(id: nil, title: nil, type: :opinion_scale, ref: nil, description: nil, steps: nil, start_at_one: nil,
+                  labels: nil, required: nil, attachment: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @steps = steps
+      @start_at_one = start_at_one
+      @labels = labels
+      @required = required
+      @attachment = attachment
     end
-    unless required.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required unless required.nil?
+
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:id] = id unless id.nil?
+      payload[:ref] = ref unless ref.nil?
+      unless description.nil? && steps.nil? && start_at_one.nil? && labels.nil?
+        payload[:properties] = {}
+        payload[:properties][:description] = description unless description.nil?
+        payload[:properties][:steps] = steps unless steps.nil?
+        payload[:properties][:start_at_one] = start_at_one unless start_at_one.nil?
+        payload[:properties][:labels] = labels unless labels.nil?
+      end
+      unless required.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required unless required.nil?
+      end
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
     end
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    (labels.nil? || labels == actual.labels) &&
-      (steps.nil? ? OpinionScaleBlock.default.steps : steps) == actual.steps &&
-      (start_at_one.nil? ? OpinionScaleBlock.default.start_at_one : start_at_one) == actual.start_at_one &&
-      (required.nil? ? OpinionScaleBlock.default.required : required) == actual.required
-  end
+    def same_extra_attributes?(actual)
+      (labels.nil? || labels == actual.labels) &&
+        (steps.nil? ? OpinionScaleBlock.default.steps : steps) == actual.steps &&
+        (start_at_one.nil? ? OpinionScaleBlock.default.start_at_one : start_at_one) == actual.start_at_one &&
+        (required.nil? ? OpinionScaleBlock.default.required : required) == actual.required
+    end
 
-  def self.default
-    OpinionScaleBlock.new(
-      steps: 11,
-      start_at_one: false,
-      required: false
-    )
-  end
+    def self.default
+      OpinionScaleBlock.new(
+        steps: 11,
+        start_at_one: false,
+        required: false
+      )
+    end
 
-  def self.full_example(id: nil)
-    OpinionScaleBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      steps: 7,
-      id: id,
-      start_at_one: true,
-      labels: { left: 'beg', center: 'mid', right: 'end' },
-      required: true,
-      attachment: Block.attachment
-    )
+    def self.full_example(id: nil)
+      OpinionScaleBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        steps: 7,
+        id: id,
+        start_at_one: true,
+        labels: { left: 'beg', center: 'mid', right: 'end' },
+        required: true,
+        attachment: Block.attachment
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/payment_block.rb
+++ b/lib/create_api_gem/forms/blocks/payment_block.rb
@@ -17,72 +17,74 @@
 
 require_relative 'block'
 
-class PaymentBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :required, :currency, :price, :show_button, :button_text, :attachment
+module Typeform
+  class PaymentBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :required, :currency, :price, :show_button, :button_text, :attachment
 
-  def initialize(id: nil, title: nil, type: :payment, ref: nil, description: nil, required: nil, currency: nil, price: nil,
-                 show_button: nil, button_text: nil, attachment: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @required = required
-    @currency = currency || 'EUR'
-    @price = price || { type: 'variable', value: 'price' }
-    @show_button = show_button
-    @button_text = button_text
-    @attachment = attachment
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:id] = id unless id.nil?
-    payload[:ref] = ref unless ref.nil?
-    unless description.nil? && currency.nil? && price.nil? && show_button.nil? && button_text.nil?
-      payload[:properties] = {}
-      payload[:properties][:description] = description unless description.nil?
-      payload[:properties][:currency] = currency unless currency.nil?
-      payload[:properties][:price] = price unless price.nil?
-      payload[:properties][:show_button] = show_button unless show_button.nil?
-      payload[:properties][:button_text] = button_text unless button_text.nil?
+    def initialize(id: nil, title: nil, type: :payment, ref: nil, description: nil, required: nil, currency: nil, price: nil,
+                  show_button: nil, button_text: nil, attachment: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @required = required
+      @currency = currency || 'EUR'
+      @price = price || { type: 'variable', value: 'price' }
+      @show_button = show_button
+      @button_text = button_text
+      @attachment = attachment
     end
-    unless required.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required
+
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:id] = id unless id.nil?
+      payload[:ref] = ref unless ref.nil?
+      unless description.nil? && currency.nil? && price.nil? && show_button.nil? && button_text.nil?
+        payload[:properties] = {}
+        payload[:properties][:description] = description unless description.nil?
+        payload[:properties][:currency] = currency unless currency.nil?
+        payload[:properties][:price] = price unless price.nil?
+        payload[:properties][:show_button] = show_button unless show_button.nil?
+        payload[:properties][:button_text] = button_text unless button_text.nil?
+      end
+      unless required.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required
+      end
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
     end
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    (required.nil? ? PaymentBlock.default.required : required) == actual.required &&
-      (price.nil? ? PaymentBlock.default.price : price) == actual.price &&
-      (currency.nil? ? PaymentBlock.default.currency : currency) == actual.currency &&
-      (show_button.nil? || show_button == actual.show_button) &&
-      (button_text.nil? || button_text == actual.button_text)
-  end
+    def same_extra_attributes?(actual)
+      (required.nil? ? PaymentBlock.default.required : required) == actual.required &&
+        (price.nil? ? PaymentBlock.default.price : price) == actual.price &&
+        (currency.nil? ? PaymentBlock.default.currency : currency) == actual.currency &&
+        (show_button.nil? || show_button == actual.show_button) &&
+        (button_text.nil? || button_text == actual.button_text)
+    end
 
-  def self.default
-    PaymentBlock.new(
-      required: false,
-      price: { type: 'variable', value: 'price' },
-      currency: 'EUR'
-    )
-  end
+    def self.default
+      PaymentBlock.new(
+        required: false,
+        price: { type: 'variable', value: 'price' },
+        currency: 'EUR'
+      )
+    end
 
-  def self.full_example(id: nil)
-    PaymentBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      id: id,
-      required: true,
-      currency: 'USD',
-      price: { type: 'variable', value: 'price' },
-      show_button: true, button_text: 'Click me!',
-      attachment: Block.attachment
-    )
+    def self.full_example(id: nil)
+      PaymentBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        id: id,
+        required: true,
+        currency: 'USD',
+        price: { type: 'variable', value: 'price' },
+        show_button: true, button_text: 'Click me!',
+        attachment: Block.attachment
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/phone_number_block.rb
+++ b/lib/create_api_gem/forms/blocks/phone_number_block.rb
@@ -17,55 +17,57 @@
 
 require_relative 'block'
 
-class PhoneNumberBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :required, :attachment, :default_country_code
+module Typeform
+  class PhoneNumberBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :required, :attachment, :default_country_code
 
-  def initialize(id: nil, title: nil, type: :phone_number, ref: nil, description: nil, required: nil, attachment: nil, default_country_code: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @required = required
-    @attachment = attachment
-    @default_country_code = default_country_code
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:id] = id unless id.nil?
-    payload[:ref] = ref unless ref.nil?
-    payload[:properties] = {}
-    payload[:properties][:description] = description unless description.nil?
-    payload[:properties][:default_country_code] = default_country_code unless default_country_code.nil?
-    unless required.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required
+    def initialize(id: nil, title: nil, type: :phone_number, ref: nil, description: nil, required: nil, attachment: nil, default_country_code: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @required = required
+      @attachment = attachment
+      @default_country_code = default_country_code
     end
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    (required.nil? ? PhoneNumberBlock.default.required : required) == actual.required
-  end
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:id] = id unless id.nil?
+      payload[:ref] = ref unless ref.nil?
+      payload[:properties] = {}
+      payload[:properties][:description] = description unless description.nil?
+      payload[:properties][:default_country_code] = default_country_code unless default_country_code.nil?
+      unless required.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required
+      end
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
+    end
 
-  def self.default
-    PhoneNumberBlock.new(
-      required: false
-    )
-  end
+    def same_extra_attributes?(actual)
+      (required.nil? ? PhoneNumberBlock.default.required : required) == actual.required
+    end
 
-  def self.full_example(id: nil)
-    PhoneNumberBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      id: id,
-      required: true,
-      attachment: Block.attachment,
-      default_country_code: 'us'
-    )
+    def self.default
+      PhoneNumberBlock.new(
+        required: false
+      )
+    end
+
+    def self.full_example(id: nil)
+      PhoneNumberBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        id: id,
+        required: true,
+        attachment: Block.attachment,
+        default_country_code: 'us'
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/picture_choice_block.rb
+++ b/lib/create_api_gem/forms/blocks/picture_choice_block.rb
@@ -17,105 +17,107 @@
 
 require_relative 'block'
 
-class PictureChoiceBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :randomize, :allow_multiple_selection, :allow_other_choice,
-                :supersized, :show_labels, :choices, :required
+module Typeform
+  class PictureChoiceBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :randomize, :allow_multiple_selection, :allow_other_choice,
+                  :supersized, :show_labels, :choices, :required
 
-  def initialize(id: nil, title: nil, type: :picture_choice, ref: nil, description: nil, randomize: nil,
-                 allow_multiple_selection: nil, allow_other_choice: nil, supersized: nil, show_labels: nil,
-                 choices: nil, required: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @randomize = randomize
-    @allow_multiple_selection = allow_multiple_selection
-    @allow_other_choice = allow_other_choice
-    @supersized = supersized
-    @show_labels = show_labels
-    @choices = choices || PictureChoiceBlock.choices
-    @required = required
-  end
-
-  def self.choices
-    [
-      {
-        label: 'label 1',
-        ref: DataGenerator.field_ref,
-        attachment: Block.image_attachment_payload(image_id: 'default')
-      },
-      {
-        label: 'label 2',
-        ref: DataGenerator.field_ref,
-        attachment: Block.image_attachment_payload(image_id: 'default')
-      }
-    ]
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:ref] = ref unless ref.nil?
-    payload[:id] = id unless id.nil?
-    payload[:properties] = {}
-    payload[:properties][:choices] = choices
-    payload[:properties][:description] = description unless description.nil?
-    payload[:properties][:randomize] = randomize unless randomize.nil?
-    payload[:properties][:allow_multiple_selection] = allow_multiple_selection unless allow_multiple_selection.nil?
-    payload[:properties][:allow_other_choice] = allow_other_choice unless allow_other_choice.nil?
-    payload[:properties][:supersized] = supersized unless supersized.nil?
-    payload[:properties][:show_labels] = show_labels unless show_labels.nil?
-    unless required.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required
+    def initialize(id: nil, title: nil, type: :picture_choice, ref: nil, description: nil, randomize: nil,
+                  allow_multiple_selection: nil, allow_other_choice: nil, supersized: nil, show_labels: nil,
+                  choices: nil, required: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @randomize = randomize
+      @allow_multiple_selection = allow_multiple_selection
+      @allow_other_choice = allow_other_choice
+      @supersized = supersized
+      @show_labels = show_labels
+      @choices = choices || PictureChoiceBlock.choices
+      @required = required
     end
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    same_choices?(actual.choices) &&
-      (randomize.nil? ? PictureChoiceBlock.default.randomize : randomize) == actual.randomize &&
-      (allow_multiple_selection.nil? ? PictureChoiceBlock.default.allow_multiple_selection : allow_multiple_selection) == actual.allow_multiple_selection &&
-      (allow_other_choice.nil? ? PictureChoiceBlock.default.allow_other_choice : allow_other_choice) == actual.allow_other_choice &&
-      (supersized.nil? ? PictureChoiceBlock.default.supersized : supersized) == actual.supersized &&
-      (show_labels.nil? ? PictureChoiceBlock.default.show_labels : show_labels) == actual.show_labels &&
-      (required.nil? ? PictureChoiceBlock.default.required : required) == actual.required
-  end
-
-  def same_choices?(actual_choices)
-    choices.zip(actual_choices).all? do |expected, actual|
-      (!expected.key?(:id) || expected[:id] == actual[:id]) &&
-        (!expected.key?(:ref) || expected[:ref] == actual[:ref]) &&
-        expected[:label] == actual[:label] &&
-        (expected[:attachment][:href].start_with?("#{APIConfig.image_api_request_url}/images/") && actual[:attachment][:href].start_with?("#{APIConfig.image_api_request_url}/images/"))
+    def self.choices
+      [
+        {
+          label: 'label 1',
+          ref: DataGenerator.field_ref,
+          attachment: Block.image_attachment_payload(image_id: 'default')
+        },
+        {
+          label: 'label 2',
+          ref: DataGenerator.field_ref,
+          attachment: Block.image_attachment_payload(image_id: 'default')
+        }
+      ]
     end
-  end
 
-  def self.default
-    PictureChoiceBlock.new(
-      randomize: false,
-      allow_multiple_selection: false,
-      allow_other_choice: false,
-      supersized: false,
-      show_labels: true,
-      required: false
-    )
-  end
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:ref] = ref unless ref.nil?
+      payload[:id] = id unless id.nil?
+      payload[:properties] = {}
+      payload[:properties][:choices] = choices
+      payload[:properties][:description] = description unless description.nil?
+      payload[:properties][:randomize] = randomize unless randomize.nil?
+      payload[:properties][:allow_multiple_selection] = allow_multiple_selection unless allow_multiple_selection.nil?
+      payload[:properties][:allow_other_choice] = allow_other_choice unless allow_other_choice.nil?
+      payload[:properties][:supersized] = supersized unless supersized.nil?
+      payload[:properties][:show_labels] = show_labels unless show_labels.nil?
+      unless required.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required
+      end
+      payload
+    end
 
-  def self.full_example(id: nil)
-    PictureChoiceBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      id: id,
-      randomize: true,
-      allow_multiple_selection: true,
-      allow_other_choice: true,
-      supersized: true,
-      choices: choices,
-      show_labels: false,
-      required: true
-    )
+    def same_extra_attributes?(actual)
+      same_choices?(actual.choices) &&
+        (randomize.nil? ? PictureChoiceBlock.default.randomize : randomize) == actual.randomize &&
+        (allow_multiple_selection.nil? ? PictureChoiceBlock.default.allow_multiple_selection : allow_multiple_selection) == actual.allow_multiple_selection &&
+        (allow_other_choice.nil? ? PictureChoiceBlock.default.allow_other_choice : allow_other_choice) == actual.allow_other_choice &&
+        (supersized.nil? ? PictureChoiceBlock.default.supersized : supersized) == actual.supersized &&
+        (show_labels.nil? ? PictureChoiceBlock.default.show_labels : show_labels) == actual.show_labels &&
+        (required.nil? ? PictureChoiceBlock.default.required : required) == actual.required
+    end
+
+    def same_choices?(actual_choices)
+      choices.zip(actual_choices).all? do |expected, actual|
+        (!expected.key?(:id) || expected[:id] == actual[:id]) &&
+          (!expected.key?(:ref) || expected[:ref] == actual[:ref]) &&
+          expected[:label] == actual[:label] &&
+          (expected[:attachment][:href].start_with?("#{APIConfig.image_api_request_url}/images/") && actual[:attachment][:href].start_with?("#{APIConfig.image_api_request_url}/images/"))
+      end
+    end
+
+    def self.default
+      PictureChoiceBlock.new(
+        randomize: false,
+        allow_multiple_selection: false,
+        allow_other_choice: false,
+        supersized: false,
+        show_labels: true,
+        required: false
+      )
+    end
+
+    def self.full_example(id: nil)
+      PictureChoiceBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        id: id,
+        randomize: true,
+        allow_multiple_selection: true,
+        allow_other_choice: true,
+        supersized: true,
+        choices: choices,
+        show_labels: false,
+        required: true
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/rating_block.rb
+++ b/lib/create_api_gem/forms/blocks/rating_block.rb
@@ -17,65 +17,67 @@
 
 require_relative 'block'
 
-class RatingBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :steps, :shape, :required, :attachment
+module Typeform
+  class RatingBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :steps, :shape, :required, :attachment
 
-  def initialize(id: nil, title: nil, type: :rating, ref: nil, description: nil, steps: nil, shape: nil,
-                 required: nil, attachment: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @steps = steps
-    @shape = shape
-    @required = required
-    @attachment = attachment
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:ref] = ref unless ref.nil?
-    payload[:id] = id unless id.nil?
-    unless description.nil? && steps.nil? && shape.nil?
-      payload[:properties] = {}
-      payload[:properties][:description] = description unless description.nil?
-      payload[:properties][:steps] = steps unless steps.nil?
-      payload[:properties][:shape] = shape unless shape.nil?
+    def initialize(id: nil, title: nil, type: :rating, ref: nil, description: nil, steps: nil, shape: nil,
+                  required: nil, attachment: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @steps = steps
+      @shape = shape
+      @required = required
+      @attachment = attachment
     end
-    unless required.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required unless required.nil?
+
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:ref] = ref unless ref.nil?
+      payload[:id] = id unless id.nil?
+      unless description.nil? && steps.nil? && shape.nil?
+        payload[:properties] = {}
+        payload[:properties][:description] = description unless description.nil?
+        payload[:properties][:steps] = steps unless steps.nil?
+        payload[:properties][:shape] = shape unless shape.nil?
+      end
+      unless required.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required unless required.nil?
+      end
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
     end
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    (steps.nil? ? RatingBlock.default.steps : steps) == actual.steps &&
-      (shape.nil? ? RatingBlock.default.shape : shape) == actual.shape &&
-      (required.nil? ? RatingBlock.default.required : required) == actual.required
-  end
+    def same_extra_attributes?(actual)
+      (steps.nil? ? RatingBlock.default.steps : steps) == actual.steps &&
+        (shape.nil? ? RatingBlock.default.shape : shape) == actual.shape &&
+        (required.nil? ? RatingBlock.default.required : required) == actual.required
+    end
 
-  def self.default
-    RatingBlock.new(
-      steps: 3,
-      shape: 'star',
-      required: false
-    )
-  end
+    def self.default
+      RatingBlock.new(
+        steps: 3,
+        shape: 'star',
+        required: false
+      )
+    end
 
-  def self.full_example(id: nil)
-    RatingBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      steps: 8,
-      shape: 'heart',
-      id: id,
-      required: true,
-      attachment: Block.attachment
-    )
+    def self.full_example(id: nil)
+      RatingBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        steps: 8,
+        shape: 'heart',
+        id: id,
+        required: true,
+        attachment: Block.attachment
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/short_text_block.rb
+++ b/lib/create_api_gem/forms/blocks/short_text_block.rb
@@ -17,59 +17,61 @@
 
 require_relative 'block'
 
-class ShortTextBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :required, :max_length, :attachment
+module Typeform
+  class ShortTextBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :required, :max_length, :attachment
 
-  def initialize(id: nil, title: nil, type: :short_text, ref: nil, description: nil, required: nil,
-                 max_length: nil, attachment: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @required = required
-    @max_length = max_length
-    @attachment = attachment
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:id] = id unless id.nil?
-    payload[:ref] = ref unless ref.nil?
-    unless description.nil?
-      payload[:properties] = {}
-      payload[:properties][:description] = description
+    def initialize(id: nil, title: nil, type: :short_text, ref: nil, description: nil, required: nil,
+                  max_length: nil, attachment: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @required = required
+      @max_length = max_length
+      @attachment = attachment
     end
-    unless required.nil? && max_length.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required unless required.nil?
-      payload[:validations][:max_length] = max_length unless max_length.nil?
+
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:id] = id unless id.nil?
+      payload[:ref] = ref unless ref.nil?
+      unless description.nil?
+        payload[:properties] = {}
+        payload[:properties][:description] = description
+      end
+      unless required.nil? && max_length.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required unless required.nil?
+        payload[:validations][:max_length] = max_length unless max_length.nil?
+      end
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
     end
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    (max_length.nil? || max_length == actual.max_length) &&
-      (required.nil? ? ShortTextBlock.default.required : required) == actual.required
-  end
+    def same_extra_attributes?(actual)
+      (max_length.nil? || max_length == actual.max_length) &&
+        (required.nil? ? ShortTextBlock.default.required : required) == actual.required
+    end
 
-  def self.default
-    ShortTextBlock.new(
-      required: false
-    )
-  end
+    def self.default
+      ShortTextBlock.new(
+        required: false
+      )
+    end
 
-  def self.full_example(id: nil)
-    ShortTextBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      id: id,
-      required: true,
-      max_length: 50,
-      attachment: Block.attachment
-    )
+    def self.full_example(id: nil)
+      ShortTextBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        id: id,
+        required: true,
+        max_length: 50,
+        attachment: Block.attachment
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/statement_block.rb
+++ b/lib/create_api_gem/forms/blocks/statement_block.rb
@@ -17,54 +17,56 @@
 
 require_relative 'block'
 
-class StatementBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :hide_marks, :button_text, :attachment
+module Typeform
+  class StatementBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :hide_marks, :button_text, :attachment
 
-  def initialize(id: nil, title: nil, type: :statement, ref: nil, description: nil, hide_marks: nil,
-                 button_text: nil, attachment: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @hide_marks = hide_marks
-    @button_text = button_text
-    @attachment = attachment
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:id] = id unless id.nil?
-    payload[:ref] = ref unless ref.nil?
-    unless description.nil? && hide_marks.nil? && button_text.nil?
-      payload[:properties] = {}
-      payload[:properties][:description] = description unless description.nil?
-      payload[:properties][:hide_marks] = hide_marks unless hide_marks.nil?
-      payload[:properties][:button_text] = button_text unless button_text.nil?
+    def initialize(id: nil, title: nil, type: :statement, ref: nil, description: nil, hide_marks: nil,
+                  button_text: nil, attachment: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @hide_marks = hide_marks
+      @button_text = button_text
+      @attachment = attachment
     end
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    (hide_marks.nil? ? StatementBlock.default.hide_marks : hide_marks) == actual.hide_marks &&
-      (button_text.nil? ? StatementBlock.default.button_text : button_text) == actual.button_text
-  end
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:id] = id unless id.nil?
+      payload[:ref] = ref unless ref.nil?
+      unless description.nil? && hide_marks.nil? && button_text.nil?
+        payload[:properties] = {}
+        payload[:properties][:description] = description unless description.nil?
+        payload[:properties][:hide_marks] = hide_marks unless hide_marks.nil?
+        payload[:properties][:button_text] = button_text unless button_text.nil?
+      end
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
+    end
 
-  def self.default
-    StatementBlock.new(button_text: 'Continue', hide_marks: false)
-  end
+    def same_extra_attributes?(actual)
+      (hide_marks.nil? ? StatementBlock.default.hide_marks : hide_marks) == actual.hide_marks &&
+        (button_text.nil? ? StatementBlock.default.button_text : button_text) == actual.button_text
+    end
 
-  def self.full_example(id: nil)
-    StatementBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      hide_marks: true,
-      id: id,
-      button_text: 'Click me!',
-      attachment: Block.attachment
-    )
+    def self.default
+      StatementBlock.new(button_text: 'Continue', hide_marks: false)
+    end
+
+    def self.full_example(id: nil)
+      StatementBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        hide_marks: true,
+        id: id,
+        button_text: 'Click me!',
+        attachment: Block.attachment
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/thank_you_screen.rb
+++ b/lib/create_api_gem/forms/blocks/thank_you_screen.rb
@@ -15,97 +15,99 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class ThankYouScreen < Block
-  attr_accessor :title, :ref, :show_button, :button_text, :button_mode, :redirect_url, :share_icons, :attachment
+module Typeform
+  class ThankYouScreen < Block
+    attr_accessor :title, :ref, :show_button, :button_text, :button_mode, :redirect_url, :share_icons, :attachment
 
-  def initialize(title: nil, ref: nil, show_button: nil, button_text: nil, button_mode: nil, redirect_url: nil, share_icons: nil, attachment: nil)
-    @title = title || DataGenerator.title
-    @ref = ref
-    @show_button = show_button
-    @button_text = button_text
-    @button_mode = button_mode
-    @redirect_url = redirect_url
-    @share_icons = share_icons
-    @attachment = attachment
-  end
-
-  def self.from_response(response)
-    properties = response[:properties]
-    block_params = response.keep_if { |k, _| k != :properties }
-    params = properties.merge(block_params)
-    ThankYouScreen.new(params)
-  end
-
-  def payload
-    payload = {}
-
-    payload[:title] = title
-    payload[:ref] = ref unless ref.nil?
-    unless show_button.nil? && button_text.nil? && button_mode.nil? && redirect_url.nil? && share_icons.nil?
-      payload[:properties] = {}
-      payload[:properties][:show_button] = show_button unless show_button.nil?
-      payload[:properties][:button_text] = button_text unless button_text.nil?
-      payload[:properties][:button_mode] = button_mode unless button_mode.nil?
-      payload[:properties][:redirect_url] = redirect_url unless redirect_url.nil?
-      payload[:properties][:share_icons] = share_icons unless share_icons.nil?
+    def initialize(title: nil, ref: nil, show_button: nil, button_text: nil, button_mode: nil, redirect_url: nil, share_icons: nil, attachment: nil)
+      @title = title || DataGenerator.title
+      @ref = ref
+      @show_button = show_button
+      @button_text = button_text
+      @button_mode = button_mode
+      @redirect_url = redirect_url
+      @share_icons = share_icons
+      @attachment = attachment
     end
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
 
-  def same?(actual)
-    title == actual.title &&
-      (ref.nil? || ref == actual.ref) &&
-      (show_button.nil? ? ThankYouScreen.default.show_button == actual.show_button : show_button == actual.show_button) &&
-      (button_text.nil? || button_text == actual.button_text) &&
-      ((button_mode.nil? ? ThankYouScreen.default.button_mode == actual.button_mode : button_mode == actual.button_mode) || ref == 'default_tys') &&
-      (redirect_url.nil? || (redirect_url == actual.redirect_url && ref != 'default_tys') || (redirect_url.include?(actual.redirect_url) || ref == 'default_tys')) &&
-      (share_icons.nil? ? ThankYouScreen.default.share_icons == actual.share_icons : share_icons == actual.share_icons) &&
-      (attachment.nil? || same_attachment?(actual.attachment) || ref == 'default_tys')
-  end
+    def self.from_response(response)
+      properties = response[:properties]
+      block_params = response.keep_if { |k, _| k != :properties }
+      params = properties.merge(block_params)
+      ThankYouScreen.new(params)
+    end
 
-  def self.default
-    ThankYouScreen.new(
-      show_button: true,
-      button_mode: 'reload',
-      share_icons: true
-    )
-  end
+    def payload
+      payload = {}
 
-  def self.default_basic(account_id: nil, form_uid: nil)
-    ThankYouScreen.new(
-      title: "Thanks for completing this typeform\nNow *create your own* — it's free, easy, & beautiful",
-      ref: 'default_tys',
-      show_button: true,
-      share_icons: false,
-      button_mode: 'redirect',
-      button_text: 'Create a *typeform*',
-      redirect_url: "/signup?utm_campaign=#{form_uid}&utm_source=typeform.com-#{account_id}-Basic&utm_medium=typeform&utm_content=typeform-thankyoubutton&utm_term=EN",
-      attachment: {
-        type: 'image',
-        href: "#{APIConfig.image_api_request_url}/images/2dpnUBBkz2VN"
-      }
-    )
-  end
+      payload[:title] = title
+      payload[:ref] = ref unless ref.nil?
+      unless show_button.nil? && button_text.nil? && button_mode.nil? && redirect_url.nil? && share_icons.nil?
+        payload[:properties] = {}
+        payload[:properties][:show_button] = show_button unless show_button.nil?
+        payload[:properties][:button_text] = button_text unless button_text.nil?
+        payload[:properties][:button_mode] = button_mode unless button_mode.nil?
+        payload[:properties][:redirect_url] = redirect_url unless redirect_url.nil?
+        payload[:properties][:share_icons] = share_icons unless share_icons.nil?
+      end
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
+    end
 
-  def self.default_pro
-    ThankYouScreen.new(
-      title: 'Done! Your information was sent perfectly.',
-      ref: 'default_tys',
-      show_button: false,
-      share_icons: false
-    )
-  end
+    def same?(actual)
+      title == actual.title &&
+        (ref.nil? || ref == actual.ref) &&
+        (show_button.nil? ? ThankYouScreen.default.show_button == actual.show_button : show_button == actual.show_button) &&
+        (button_text.nil? || button_text == actual.button_text) &&
+        ((button_mode.nil? ? ThankYouScreen.default.button_mode == actual.button_mode : button_mode == actual.button_mode) || ref == 'default_tys') &&
+        (redirect_url.nil? || (redirect_url == actual.redirect_url && ref != 'default_tys') || (redirect_url.include?(actual.redirect_url) || ref == 'default_tys')) &&
+        (share_icons.nil? ? ThankYouScreen.default.share_icons == actual.share_icons : share_icons == actual.share_icons) &&
+        (attachment.nil? || same_attachment?(actual.attachment) || ref == 'default_tys')
+    end
 
-  def self.full_example
-    ThankYouScreen.new(
-      ref: DataGenerator.field_ref,
-      show_button: false,
-      button_text: 'Click me!',
-      button_mode: 'redirect',
-      redirect_url: 'http://www.google.com',
-      share_icons: false,
-      attachment: Block.attachment
-    )
+    def self.default
+      ThankYouScreen.new(
+        show_button: true,
+        button_mode: 'reload',
+        share_icons: true
+      )
+    end
+
+    def self.default_basic(account_id: nil, form_uid: nil)
+      ThankYouScreen.new(
+        title: "Thanks for completing this typeform\nNow *create your own* — it's free, easy, & beautiful",
+        ref: 'default_tys',
+        show_button: true,
+        share_icons: false,
+        button_mode: 'redirect',
+        button_text: 'Create a *typeform*',
+        redirect_url: "/signup?utm_campaign=#{form_uid}&utm_source=typeform.com-#{account_id}-Basic&utm_medium=typeform&utm_content=typeform-thankyoubutton&utm_term=EN",
+        attachment: {
+          type: 'image',
+          href: "#{APIConfig.image_api_request_url}/images/2dpnUBBkz2VN"
+        }
+      )
+    end
+
+    def self.default_pro
+      ThankYouScreen.new(
+        title: 'Done! Your information was sent perfectly.',
+        ref: 'default_tys',
+        show_button: false,
+        share_icons: false
+      )
+    end
+
+    def self.full_example
+      ThankYouScreen.new(
+        ref: DataGenerator.field_ref,
+        show_button: false,
+        button_text: 'Click me!',
+        button_mode: 'redirect',
+        redirect_url: 'http://www.google.com',
+        share_icons: false,
+        attachment: Block.attachment
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/website_block.rb
+++ b/lib/create_api_gem/forms/blocks/website_block.rb
@@ -17,51 +17,53 @@
 
 require_relative 'block'
 
-class WebsiteBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :required
+module Typeform
+  class WebsiteBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :required
 
-  def initialize(id: nil, title: nil, type: :website, ref: nil, description: nil, required: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @required = required
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:id] = id unless id.nil?
-    payload[:ref] = ref unless ref.nil?
-    unless description.nil?
-      payload[:properties] = {}
-      payload[:properties][:description] = description
+    def initialize(id: nil, title: nil, type: :website, ref: nil, description: nil, required: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @required = required
     end
-    unless required.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required
+
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:id] = id unless id.nil?
+      payload[:ref] = ref unless ref.nil?
+      unless description.nil?
+        payload[:properties] = {}
+        payload[:properties][:description] = description
+      end
+      unless required.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required
+      end
+      payload
     end
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    (required.nil? ? WebsiteBlock.default.required : required) == actual.required
-  end
+    def same_extra_attributes?(actual)
+      (required.nil? ? WebsiteBlock.default.required : required) == actual.required
+    end
 
-  def self.default
-    WebsiteBlock.new(
-      required: false
-    )
-  end
+    def self.default
+      WebsiteBlock.new(
+        required: false
+      )
+    end
 
-  def self.full_example(id: nil)
-    WebsiteBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      required: true,
-      id: id
-    )
+    def self.full_example(id: nil)
+      WebsiteBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        required: true,
+        id: id
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/welcome_screen.rb
+++ b/lib/create_api_gem/forms/blocks/welcome_screen.rb
@@ -15,57 +15,59 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class WelcomeScreen < Block
-  attr_accessor :id, :title, :ref, :type, :description, :show_button, :button_text, :attachment
+module Typeform
+  class WelcomeScreen < Block
+    attr_accessor :id, :title, :ref, :type, :description, :show_button, :button_text, :attachment
 
-  def initialize(id: nil, title: nil, type: :welcome_screen, ref: nil, description: nil, show_button: nil, button_text: nil, attachment: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @ref = ref
-    @type = type
-    @description = description
-    @show_button = show_button
-    @button_text = button_text
-    @attachment = attachment
-  end
+    def initialize(id: nil, title: nil, type: :welcome_screen, ref: nil, description: nil, show_button: nil, button_text: nil, attachment: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @ref = ref
+      @type = type
+      @description = description
+      @show_button = show_button
+      @button_text = button_text
+      @attachment = attachment
+    end
 
-  def self.from_response(response)
-    properties = response[:properties]
-    block_params = response.keep_if { |k, _| k != :properties }
-    params = properties.merge(block_params)
-    WelcomeScreen.new(params)
-  end
+    def self.from_response(response)
+      properties = response[:properties]
+      block_params = response.keep_if { |k, _| k != :properties }
+      params = properties.merge(block_params)
+      WelcomeScreen.new(params)
+    end
 
-  def payload
-    payload = {}
-    payload[:properties] = {}
+    def payload
+      payload = {}
+      payload[:properties] = {}
 
-    payload[:title] = title
-    payload[:ref] = ref unless ref.nil?
-    payload[:properties][:description] = description unless description.nil?
-    payload[:properties][:show_button] = show_button unless show_button.nil?
-    payload[:properties][:button_text] = button_text unless button_text.nil?
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
+      payload[:title] = title
+      payload[:ref] = ref unless ref.nil?
+      payload[:properties][:description] = description unless description.nil?
+      payload[:properties][:show_button] = show_button unless show_button.nil?
+      payload[:properties][:button_text] = button_text unless button_text.nil?
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
+    end
 
-  def same_extra_attributes?(actual)
-    (show_button.nil? ? WelcomeScreen.default.show_button == actual.show_button : show_button == actual.show_button) &&
-      (button_text.nil? ? WelcomeScreen.default.button_text == actual.button_text : button_text == actual.button_text)
-  end
+    def same_extra_attributes?(actual)
+      (show_button.nil? ? WelcomeScreen.default.show_button == actual.show_button : show_button == actual.show_button) &&
+        (button_text.nil? ? WelcomeScreen.default.button_text == actual.button_text : button_text == actual.button_text)
+    end
 
-  def self.default
-    WelcomeScreen.new(show_button: true, button_text: 'start')
-  end
+    def self.default
+      WelcomeScreen.new(show_button: true, button_text: 'start')
+    end
 
-  def self.full_example(id: nil)
-    WelcomeScreen.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      show_button: false,
-      button_text: 'Click me!',
-      id: id,
-      attachment: Block.attachment
-    )
+    def self.full_example(id: nil)
+      WelcomeScreen.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        show_button: false,
+        button_text: 'Click me!',
+        id: id,
+        attachment: Block.attachment
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/blocks/yes_no_block.rb
+++ b/lib/create_api_gem/forms/blocks/yes_no_block.rb
@@ -17,54 +17,56 @@
 
 require_relative 'block'
 
-class YesNoBlock < Block
-  attr_accessor :id, :title, :type, :ref, :description, :required, :attachment
+module Typeform
+  class YesNoBlock < Block
+    attr_accessor :id, :title, :type, :ref, :description, :required, :attachment
 
-  def initialize(id: nil, title: nil, type: :yes_no, ref: nil, description: nil, required: nil, attachment: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @type = type
-    @ref = ref
-    @description = description
-    @required = required
-    @attachment = attachment
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:type] = type.to_s
-    payload[:id] = id unless id.nil?
-    payload[:ref] = ref unless ref.nil?
-    unless description.nil?
-      payload[:properties] = {}
-      payload[:properties][:description] = description
+    def initialize(id: nil, title: nil, type: :yes_no, ref: nil, description: nil, required: nil, attachment: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @type = type
+      @ref = ref
+      @description = description
+      @required = required
+      @attachment = attachment
     end
-    unless required.nil?
-      payload[:validations] = {}
-      payload[:validations][:required] = required
+
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:type] = type.to_s
+      payload[:id] = id unless id.nil?
+      payload[:ref] = ref unless ref.nil?
+      unless description.nil?
+        payload[:properties] = {}
+        payload[:properties][:description] = description
+      end
+      unless required.nil?
+        payload[:validations] = {}
+        payload[:validations][:required] = required
+      end
+      payload[:attachment] = attachment unless attachment.nil?
+      payload
     end
-    payload[:attachment] = attachment unless attachment.nil?
-    payload
-  end
 
-  def same_extra_attributes?(actual)
-    (required.nil? ? YesNoBlock.default.required : required) == actual.required
-  end
+    def same_extra_attributes?(actual)
+      (required.nil? ? YesNoBlock.default.required : required) == actual.required
+    end
 
-  def self.default
-    YesNoBlock.new(
-      required: false
-    )
-  end
+    def self.default
+      YesNoBlock.new(
+        required: false
+      )
+    end
 
-  def self.full_example(id: nil)
-    YesNoBlock.new(
-      ref: DataGenerator.field_ref,
-      description: DataGenerator.description,
-      required: true,
-      attachment: Block.attachment,
-      id: id
-    )
+    def self.full_example(id: nil)
+      YesNoBlock.new(
+        ref: DataGenerator.field_ref,
+        description: DataGenerator.description,
+        required: true,
+        attachment: Block.attachment,
+        id: id
+      )
+    end
   end
 end

--- a/lib/create_api_gem/forms/form.rb
+++ b/lib/create_api_gem/forms/form.rb
@@ -15,137 +15,139 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class Form
-  attr_accessor :id, :title, :blocks, :hidden, :theme_url, :workspace_url, :welcome_screens, :thank_you_screens, :logic, :settings, :variables
+module Typeform
+  class Form
+    attr_accessor :id, :title, :blocks, :hidden, :theme_url, :workspace_url, :welcome_screens, :thank_you_screens, :logic, :settings, :variables
 
-  def initialize(id: nil, title: nil, blocks: [], hidden: [], theme_url: nil, workspace_url: nil, welcome_screens: [], thank_you_screens: [], logic: [], settings: nil, variables: nil)
-    @id = id
-    @title = title || DataGenerator.title
-    @blocks = blocks
-    @hidden = hidden
-    @theme_url = theme_url
-    @workspace_url = workspace_url
-    @welcome_screens = welcome_screens
-    @thank_you_screens = thank_you_screens
-    @logic = logic
-    @settings = settings
-    @variables = variables
-  end
-
-  def self.from_response(payload)
-    blocks = payload[:fields].nil? ? [] : payload[:fields].map { |field_payload| Block.from_response(field_payload) }
-    welcome_screens = payload[:welcome_screens].nil? ? [] : payload[:welcome_screens].map { |welcome_screen_payload| WelcomeScreen.from_response(welcome_screen_payload) }
-    thank_you_screens = payload[:thankyou_screens].map { |thank_you_screen_payload| ThankYouScreen.from_response(thank_you_screen_payload) }
-    hidden_fields = payload[:hidden].nil? ? [] : payload[:hidden]
-    logic = payload[:logic].nil? ? [] : payload[:logic].map { |logic_payload| FieldLogic.from_response(logic_payload) }
-    settings = Settings.from_response(payload[:settings])
-    variables = payload[:variables].nil? ? nil : Variables.from_response(payload[:variables])
-    new(
-      id: payload[:id],
-      title: payload[:title],
-      blocks: blocks,
-      hidden: hidden_fields,
-      theme_url: payload[:theme][:href],
-      workspace_url: payload[:workspace][:href],
-      welcome_screens: welcome_screens,
-      thank_you_screens: thank_you_screens,
-      logic: logic,
-      settings: settings,
-      variables: variables
-    )
-  end
-
-  def payload
-    payload = {}
-    payload[:title] = title
-    payload[:id] = id unless id.nil?
-    payload[:hidden] = hidden unless hidden.empty?
-    payload[:theme] = { href: theme_url } unless theme_url.nil?
-    payload[:workspace] = { href: workspace_url } unless workspace_url.nil?
-    payload[:fields] = blocks.map(&:payload) unless blocks.empty?
-    payload[:welcome_screens] = welcome_screens.map(&:payload) unless welcome_screens.empty?
-    payload[:thankyou_screens] = thank_you_screens.map(&:payload) unless thank_you_screens.empty?
-    payload[:logic] = logic.map(&:payload) unless logic.empty?
-    payload[:settings] = settings.payload unless settings.nil?
-    payload[:variables] = variables.payload unless variables.nil?
-    payload.to_json
-  end
-
-  def same?(actual)
-    (id.nil? || id == actual.id) &&
-      (hidden.nil? || hidden == actual.hidden) &&
-      (theme_url.nil? || theme_url.include?('default') || theme_url == actual.theme_url) &&
-      (workspace_url.nil? || workspace_url == actual.workspace_url) &&
-      title == actual.title &&
-      same_blocks?(actual.blocks) &&
-      same_welcome_screens?(actual.welcome_screens) &&
-      same_thank_you_screens?(actual.thank_you_screens) &&
-      same_logic?(actual.logic) &&
-      (settings.nil? ? Settings.default : settings).same?(actual.settings) &&
-      (variables.nil? || variables.same?(actual.variables))
-  end
-
-  def same_blocks?(actual_blocks)
-    blocks.zip(actual_blocks).all? do |expected, actual|
-      expected.same?(actual)
-    end && blocks.length == actual_blocks.length
-  end
-
-  def same_welcome_screens?(actual_welcome_screens)
-    welcome_screens.zip(actual_welcome_screens).all? do |expected, actual|
-      expected.same?(actual)
-    end && welcome_screens.length == actual_welcome_screens.length
-  end
-
-  def same_thank_you_screens?(actual_thank_you_screens)
-    thank_you_screens.delete_if { |tys| tys.ref == 'default_tys' }
-    actual_thank_you_screens.delete_if { |tys| tys.ref == 'default_tys' }
-    thank_you_screens.zip(actual_thank_you_screens).all? do |expected, actual|
-      expected.same?(actual)
+    def initialize(id: nil, title: nil, blocks: [], hidden: [], theme_url: nil, workspace_url: nil, welcome_screens: [], thank_you_screens: [], logic: [], settings: nil, variables: nil)
+      @id = id
+      @title = title || DataGenerator.title
+      @blocks = blocks
+      @hidden = hidden
+      @theme_url = theme_url
+      @workspace_url = workspace_url
+      @welcome_screens = welcome_screens
+      @thank_you_screens = thank_you_screens
+      @logic = logic
+      @settings = settings
+      @variables = variables
     end
-  end
 
-  def same_logic?(actual_logic)
-    logic.all? do |field_logic|
-      actual_field_logic = actual_logic.find { |fl| fl.field_ref == field_logic.field_ref }
-      field_logic.same?(actual_field_logic)
-    end && logic.length == actual_logic.length
-  end
+    def self.from_response(payload)
+      blocks = payload[:fields].nil? ? [] : payload[:fields].map { |field_payload| Block.from_response(field_payload) }
+      welcome_screens = payload[:welcome_screens].nil? ? [] : payload[:welcome_screens].map { |welcome_screen_payload| WelcomeScreen.from_response(welcome_screen_payload) }
+      thank_you_screens = payload[:thankyou_screens].map { |thank_you_screen_payload| ThankYouScreen.from_response(thank_you_screen_payload) }
+      hidden_fields = payload[:hidden].nil? ? [] : payload[:hidden]
+      logic = payload[:logic].nil? ? [] : payload[:logic].map { |logic_payload| FieldLogic.from_response(logic_payload) }
+      settings = Settings.from_response(payload[:settings])
+      variables = payload[:variables].nil? ? nil : Variables.from_response(payload[:variables])
+      new(
+        id: payload[:id],
+        title: payload[:title],
+        blocks: blocks,
+        hidden: hidden_fields,
+        theme_url: payload[:theme][:href],
+        workspace_url: payload[:workspace][:href],
+        welcome_screens: welcome_screens,
+        thank_you_screens: thank_you_screens,
+        logic: logic,
+        settings: settings,
+        variables: variables
+      )
+    end
 
-  def theme_id
-    theme_url.split('/themes/')[1]
-  end
+    def payload
+      payload = {}
+      payload[:title] = title
+      payload[:id] = id unless id.nil?
+      payload[:hidden] = hidden unless hidden.empty?
+      payload[:theme] = { href: theme_url } unless theme_url.nil?
+      payload[:workspace] = { href: workspace_url } unless workspace_url.nil?
+      payload[:fields] = blocks.map(&:payload) unless blocks.empty?
+      payload[:welcome_screens] = welcome_screens.map(&:payload) unless welcome_screens.empty?
+      payload[:thankyou_screens] = thank_you_screens.map(&:payload) unless thank_you_screens.empty?
+      payload[:logic] = logic.map(&:payload) unless logic.empty?
+      payload[:settings] = settings.payload unless settings.nil?
+      payload[:variables] = variables.payload unless variables.nil?
+      payload.to_json
+    end
 
-  def workspace_id
-    workspace_url.split('/workspaces/')[1]
-  end
+    def same?(actual)
+      (id.nil? || id == actual.id) &&
+        (hidden.nil? || hidden == actual.hidden) &&
+        (theme_url.nil? || theme_url.include?('default') || theme_url == actual.theme_url) &&
+        (workspace_url.nil? || workspace_url == actual.workspace_url) &&
+        title == actual.title &&
+        same_blocks?(actual.blocks) &&
+        same_welcome_screens?(actual.welcome_screens) &&
+        same_thank_you_screens?(actual.thank_you_screens) &&
+        same_logic?(actual.logic) &&
+        (settings.nil? ? Settings.default : settings).same?(actual.settings) &&
+        (variables.nil? || variables.same?(actual.variables))
+    end
 
-  def add_logic_action(field_ref, logic_action)
-    field_logic = logic.find { |current_field_logic| current_field_logic.field_ref == field_ref }
-    field_logic.nil? ? logic << FieldLogic.new(type: 'field', field_ref: field_ref, actions: [logic_action]) : field_logic.actions << logic_action
-  end
+    def same_blocks?(actual_blocks)
+      blocks.zip(actual_blocks).all? do |expected, actual|
+        expected.same?(actual)
+      end && blocks.length == actual_blocks.length
+    end
 
-  def self.with_all_blocks
-    blocks = Block.all_types.values.map(&:new)
-    Form.new(
-      blocks: blocks
-    )
-  end
+    def same_welcome_screens?(actual_welcome_screens)
+      welcome_screens.zip(actual_welcome_screens).all? do |expected, actual|
+        expected.same?(actual)
+      end && welcome_screens.length == actual_welcome_screens.length
+    end
 
-  def self.full_example(id: nil)
-    blocks = Block.all_types.values.map(&:full_example)
-    email_block = blocks.find { |current_block| current_block.type == :email }
-    form = Form.new(
-      id: id,
-      hidden: %w[hiddenfield1 hiddenfield2],
-      theme_url: "#{APIConfig.api_request_url}/themes/default",
-      blocks: blocks,
-      welcome_screens: [WelcomeScreen.full_example],
-      thank_you_screens: [ThankYouScreen.full_example],
-      settings: Settings.full_example(email_block.ref),
-      variables: Variables.full_example
-    )
-    form.logic = blocks.map { |block| FieldLogic.full_example(block, form) }
-    form
+    def same_thank_you_screens?(actual_thank_you_screens)
+      thank_you_screens.delete_if { |tys| tys.ref == 'default_tys' }
+      actual_thank_you_screens.delete_if { |tys| tys.ref == 'default_tys' }
+      thank_you_screens.zip(actual_thank_you_screens).all? do |expected, actual|
+        expected.same?(actual)
+      end
+    end
+
+    def same_logic?(actual_logic)
+      logic.all? do |field_logic|
+        actual_field_logic = actual_logic.find { |fl| fl.field_ref == field_logic.field_ref }
+        field_logic.same?(actual_field_logic)
+      end && logic.length == actual_logic.length
+    end
+
+    def theme_id
+      theme_url.split('/themes/')[1]
+    end
+
+    def workspace_id
+      workspace_url.split('/workspaces/')[1]
+    end
+
+    def add_logic_action(field_ref, logic_action)
+      field_logic = logic.find { |current_field_logic| current_field_logic.field_ref == field_ref }
+      field_logic.nil? ? logic << FieldLogic.new(type: 'field', field_ref: field_ref, actions: [logic_action]) : field_logic.actions << logic_action
+    end
+
+    def self.with_all_blocks
+      blocks = Block.all_types.values.map(&:new)
+      Form.new(
+        blocks: blocks
+      )
+    end
+
+    def self.full_example(id: nil)
+      blocks = Block.all_types.values.map(&:full_example)
+      email_block = blocks.find { |current_block| current_block.type == :email }
+      form = Form.new(
+        id: id,
+        hidden: %w[hiddenfield1 hiddenfield2],
+        theme_url: "#{APIConfig.api_request_url}/themes/default",
+        blocks: blocks,
+        welcome_screens: [WelcomeScreen.full_example],
+        thank_you_screens: [ThankYouScreen.full_example],
+        settings: Settings.full_example(email_block.ref),
+        variables: Variables.full_example
+      )
+      form.logic = blocks.map { |block| FieldLogic.full_example(block, form) }
+      form
+    end
   end
 end

--- a/lib/create_api_gem/forms/logic/actions/calculation.rb
+++ b/lib/create_api_gem/forms/logic/actions/calculation.rb
@@ -17,56 +17,58 @@
 
 require_relative '../logic_action'
 
-class Calculation < LogicAction
-  attr_accessor :action_type, :numeric_value, :target_ref, :logic_condition
+module Typeform
+  class Calculation < LogicAction
+    attr_accessor :action_type, :numeric_value, :target_ref, :logic_condition
 
-  def initialize(action_type: nil, numeric_value: nil, target_ref: nil, logic_condition: nil)
-    @action_type = action_type
-    @numeric_value = numeric_value
-    @target_ref = target_ref
-    @logic_condition = logic_condition
-  end
+    def initialize(action_type: nil, numeric_value: nil, target_ref: nil, logic_condition: nil)
+      @action_type = action_type
+      @numeric_value = numeric_value
+      @target_ref = target_ref
+      @logic_condition = logic_condition
+    end
 
-  def self.from_response(payload)
-    action_type = payload[:action]
-    target_ref = payload[:details][:target][:value]
-    numeric_value = payload[:details][:value][:value]
-    logic_condition = LogicCondition.from_response(payload[:condition])
-    Calculation.new(action_type: action_type, numeric_value: numeric_value, target_ref: target_ref, logic_condition: logic_condition)
-  end
+    def self.from_response(payload)
+      action_type = payload[:action]
+      target_ref = payload[:details][:target][:value]
+      numeric_value = payload[:details][:value][:value]
+      logic_condition = LogicCondition.from_response(payload[:condition])
+      Calculation.new(action_type: action_type, numeric_value: numeric_value, target_ref: target_ref, logic_condition: logic_condition)
+    end
 
-  def payload
-    payload = {}
-    payload[:action] = action_type
-    payload[:details] = { target: { type: 'variable', value: target_ref } }
-    payload[:details][:value] = { type: 'constant', value: numeric_value }
-    payload[:condition] = logic_condition.payload
-    payload
-  end
+    def payload
+      payload = {}
+      payload[:action] = action_type
+      payload[:details] = { target: { type: 'variable', value: target_ref } }
+      payload[:details][:value] = { type: 'constant', value: numeric_value }
+      payload[:condition] = logic_condition.payload
+      payload
+    end
 
-  def self.full_example(block)
-    is_blocks = %i[multiple_choice picture_choice yes_no legal]
-    logic_condition = if is_blocks.include?(block.type)
-                        LogicCondition.generate_from_block(block, op: 'is')
-                      elsif block.type == :date
-                        LogicCondition.generate_from_block(block, op: 'on')
-                      elsif block.type == :file_upload
-                        LogicCondition.generate_from_block(block, op: 'answered')
-                      else
-                        LogicCondition.generate_from_block(block, op: 'equal')
-                      end
-    Calculation.new(
-      action_type: 'add',
-      numeric_value: 5,
-      target_ref: 'score',
-      logic_condition: logic_condition
-    )
-  end
+    def self.full_example(block)
+      is_blocks = %i[multiple_choice picture_choice yes_no legal]
+      logic_condition = if is_blocks.include?(block.type)
+                          LogicCondition.generate_from_block(block, op: 'is')
+                        elsif block.type == :date
+                          LogicCondition.generate_from_block(block, op: 'on')
+                        elsif block.type == :file_upload
+                          LogicCondition.generate_from_block(block, op: 'answered')
+                        else
+                          LogicCondition.generate_from_block(block, op: 'equal')
+                        end
+      Calculation.new(
+        action_type: 'add',
+        numeric_value: 5,
+        target_ref: 'score',
+        logic_condition: logic_condition
+      )
+    end
 
-  def same?(actual)
-    action_type == actual.action_type &&
-      target_ref == actual.target_ref &&
-      numeric_value == actual.numeric_value &&
-      logic_condition.same?(actual.logic_condition)
+    def same?(actual)
+      action_type == actual.action_type &&
+        target_ref == actual.target_ref &&
+        numeric_value == actual.numeric_value &&
+        logic_condition.same?(actual.logic_condition)
+    end
   end
 end

--- a/lib/create_api_gem/forms/logic/actions/logic_jump.rb
+++ b/lib/create_api_gem/forms/logic/actions/logic_jump.rb
@@ -17,74 +17,76 @@
 
 require_relative '../logic_action'
 
-class LogicJump < LogicAction
-  attr_accessor :to_type, :to_ref, :logic_condition
+module Typeform
+  class LogicJump < LogicAction
+    attr_accessor :to_type, :to_ref, :logic_condition
 
-  def initialize(to_type: nil, to_ref: nil, logic_condition: nil)
-    @to_type = to_type
-    @to_ref = to_ref
-    @logic_condition = logic_condition
-  end
+    def initialize(to_type: nil, to_ref: nil, logic_condition: nil)
+      @to_type = to_type
+      @to_ref = to_ref
+      @logic_condition = logic_condition
+    end
 
-  def self.from_response(payload)
-    to_type = payload[:details][:to][:type]
-    to_ref = payload[:details][:to][:value]
-    logic_condition = LogicCondition.from_response(payload[:condition])
-    LogicJump.new(to_type: to_type, to_ref: to_ref, logic_condition: logic_condition)
-  end
+    def self.from_response(payload)
+      to_type = payload[:details][:to][:type]
+      to_ref = payload[:details][:to][:value]
+      logic_condition = LogicCondition.from_response(payload[:condition])
+      LogicJump.new(to_type: to_type, to_ref: to_ref, logic_condition: logic_condition)
+    end
 
-  def self.create_field_logic_jump(form, block_type)
-    logic_block = form.blocks.find { |block| Block.block_symbol_to_string(block.type) == block_type }
-    to_ref = if form.blocks.last.ref == logic_block.ref
-               form.blocks.first.ref
-             else
-               form.blocks.last.ref
-             end
-    logic_condition = LogicCondition.generate_from_block(logic_block)
-    LogicJump.new(to_type: 'field', to_ref: to_ref, logic_condition: logic_condition)
-  end
+    def self.create_field_logic_jump(form, block_type)
+      logic_block = form.blocks.find { |block| Block.block_symbol_to_string(block.type) == block_type }
+      to_ref = if form.blocks.last.ref == logic_block.ref
+                 form.blocks.first.ref
+               else
+                 form.blocks.last.ref
+               end
+      logic_condition = LogicCondition.generate_from_block(logic_block)
+      LogicJump.new(to_type: 'field', to_ref: to_ref, logic_condition: logic_condition)
+    end
 
-  def self.create_always_jump(form)
-    LogicJump.new(to_type: 'field', to_ref: form.blocks.first.ref, logic_condition: LogicCondition.new(op: 'always'))
-  end
+    def self.create_always_jump(form)
+      LogicJump.new(to_type: 'field', to_ref: form.blocks.first.ref, logic_condition: LogicCondition.new(op: 'always'))
+    end
 
-  def self.create_hidden_logic_jump(form)
-    logic_condition_details = LogicConditionDetails.new(reference_type: 'hidden', reference: form.hidden[0], value_type: 'constant', value: 'abc')
-    logic_condition = LogicCondition.new(op: 'equal', vars: [logic_condition_details])
-    LogicJump.new(to_type: 'field', to_ref: form.blocks.first.ref, logic_condition: logic_condition)
-  end
+    def self.create_hidden_logic_jump(form)
+      logic_condition_details = LogicConditionDetails.new(reference_type: 'hidden', reference: form.hidden[0], value_type: 'constant', value: 'abc')
+      logic_condition = LogicCondition.new(op: 'equal', vars: [logic_condition_details])
+      LogicJump.new(to_type: 'field', to_ref: form.blocks.first.ref, logic_condition: logic_condition)
+    end
 
-  def self.create_variable_logic_jump(form)
-    logic_condition_details = LogicConditionDetails.new(reference_type: 'variable', reference: 'score', value_type: 'constant', value: 5)
-    logic_condition = LogicCondition.new(op: 'equal', vars: [logic_condition_details])
-    LogicJump.new(to_type: 'field', to_ref: form.blocks.first.ref, logic_condition: logic_condition)
-  end
+    def self.create_variable_logic_jump(form)
+      logic_condition_details = LogicConditionDetails.new(reference_type: 'variable', reference: 'score', value_type: 'constant', value: 5)
+      logic_condition = LogicCondition.new(op: 'equal', vars: [logic_condition_details])
+      LogicJump.new(to_type: 'field', to_ref: form.blocks.first.ref, logic_condition: logic_condition)
+    end
 
-  def self.create_nested_logic_jump(form)
-    logic_condition1 = LogicCondition.generate_from_block(form.blocks[0])
-    logic_condition2 = LogicCondition.generate_from_block(form.blocks[1])
-    logic_condition3 = LogicCondition.generate_from_block(form.blocks[2])
-    and_logic_condition = LogicCondition.new(op: 'and', vars: [logic_condition1, logic_condition2])
-    or_logic_condition = LogicCondition.new(op: 'or', vars: [logic_condition3, and_logic_condition])
-    LogicJump.new(to_type: 'field', to_ref: form.blocks.last.ref, logic_condition: or_logic_condition)
-  end
+    def self.create_nested_logic_jump(form)
+      logic_condition1 = LogicCondition.generate_from_block(form.blocks[0])
+      logic_condition2 = LogicCondition.generate_from_block(form.blocks[1])
+      logic_condition3 = LogicCondition.generate_from_block(form.blocks[2])
+      and_logic_condition = LogicCondition.new(op: 'and', vars: [logic_condition1, logic_condition2])
+      or_logic_condition = LogicCondition.new(op: 'or', vars: [logic_condition3, and_logic_condition])
+      LogicJump.new(to_type: 'field', to_ref: form.blocks.last.ref, logic_condition: or_logic_condition)
+    end
 
-  def self.create_thankyou_logic_jump(form)
-    logic_condition = LogicCondition.generate_from_block(form.blocks[0])
-    LogicJump.new(to_type: 'thankyou', to_ref: form.thank_you_screens.first.ref, logic_condition: logic_condition)
-  end
+    def self.create_thankyou_logic_jump(form)
+      logic_condition = LogicCondition.generate_from_block(form.blocks[0])
+      LogicJump.new(to_type: 'thankyou', to_ref: form.thank_you_screens.first.ref, logic_condition: logic_condition)
+    end
 
-  def payload
-    payload = {}
-    payload[:action] = 'jump'
-    payload[:details] = { to: { type: to_type, value: to_ref } }
-    payload[:condition] = logic_condition.payload
-    payload
-  end
+    def payload
+      payload = {}
+      payload[:action] = 'jump'
+      payload[:details] = { to: { type: to_type, value: to_ref } }
+      payload[:condition] = logic_condition.payload
+      payload
+    end
 
-  def same?(actual)
-    to_type == actual.to_type &&
-      to_ref == actual.to_ref &&
-      logic_condition.same?(actual.logic_condition)
+    def same?(actual)
+      to_type == actual.to_type &&
+        to_ref == actual.to_ref &&
+        logic_condition.same?(actual.logic_condition)
+    end
   end
 end

--- a/lib/create_api_gem/forms/logic/field_logic.rb
+++ b/lib/create_api_gem/forms/logic/field_logic.rb
@@ -15,57 +15,59 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class FieldLogic
-  attr_accessor :field_ref, :type, :actions
+module Typeform
+  class FieldLogic
+    attr_accessor :field_ref, :type, :actions
 
-  def initialize(field_ref: nil, type: nil, actions: [])
-    @field_ref = field_ref
-    @actions = actions
-    @type = type
-  end
+    def initialize(field_ref: nil, type: nil, actions: [])
+      @field_ref = field_ref
+      @actions = actions
+      @type = type
+    end
 
-  def self.from_response(payload)
-    field_ref = payload[:ref] unless payload[:ref].nil?
-    actions = payload[:actions].nil? ? [] : payload[:actions].map { |action_payload| LogicAction.from_response(action_payload) }
-    type = payload[:type]
-    FieldLogic.new(field_ref: field_ref, type: type, actions: actions)
-  end
+    def self.from_response(payload)
+      field_ref = payload[:ref] unless payload[:ref].nil?
+      actions = payload[:actions].nil? ? [] : payload[:actions].map { |action_payload| LogicAction.from_response(action_payload) }
+      type = payload[:type]
+      FieldLogic.new(field_ref: field_ref, type: type, actions: actions)
+    end
 
-  def payload
-    payload = {}
-    payload[:ref] = field_ref unless field_ref.nil?
-    payload[:type] = type unless type.nil?
-    payload[:actions] = actions.map(&:payload) unless actions.empty?
-    payload
-  end
+    def payload
+      payload = {}
+      payload[:ref] = field_ref unless field_ref.nil?
+      payload[:type] = type unless type.nil?
+      payload[:actions] = actions.map(&:payload) unless actions.empty?
+      payload
+    end
 
-  def same?(actual)
-    (field_ref.nil? || field_ref == actual.field_ref) &&
-      type == actual.type &&
-      actions.all? do |action|
-        actual_action = actual.actions.find do |a|
-          begin
-            a.same?(action)
-          rescue NoMethodError
-            false
+    def same?(actual)
+      (field_ref.nil? || field_ref == actual.field_ref) &&
+        type == actual.type &&
+        actions.all? do |action|
+          actual_action = actual.actions.find do |a|
+            begin
+              a.same?(action)
+            rescue NoMethodError
+              false
+            end
           end
-        end
-        action.same?(actual_action)
-      end && actions.length == actual.actions.length
-  end
+          action.same?(actual_action)
+        end && actions.length == actual.actions.length
+    end
 
-  def self.full_example(logic_block, form)
-    non_logic_blocks = %i[group payment statement]
-    actions = if non_logic_blocks.include?(logic_block.type)
-                [
-                  LogicJump.create_always_jump(form)
-                ]
-              else
-                [
-                  LogicJump.create_field_logic_jump(form, Block.block_symbol_to_string(logic_block.type)),
-                  Calculation.full_example(logic_block)
-                ]
-              end
-    FieldLogic.new(field_ref: logic_block.ref, type: 'field', actions: actions)
+    def self.full_example(logic_block, form)
+      non_logic_blocks = %i[group payment statement]
+      actions = if non_logic_blocks.include?(logic_block.type)
+                  [
+                    LogicJump.create_always_jump(form)
+                  ]
+                else
+                  [
+                    LogicJump.create_field_logic_jump(form, Block.block_symbol_to_string(logic_block.type)),
+                    Calculation.full_example(logic_block)
+                  ]
+                end
+      FieldLogic.new(field_ref: logic_block.ref, type: 'field', actions: actions)
+    end
   end
 end

--- a/lib/create_api_gem/forms/logic/logic_action.rb
+++ b/lib/create_api_gem/forms/logic/logic_action.rb
@@ -15,13 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class LogicAction
-  def self.from_response(payload)
-    case payload[:action]
-    when 'jump'
-      LogicJump.from_response(payload)
-    when 'add', 'subtract', 'multiply', 'divide'
-      Calculation.from_response(payload)
+module Typeform
+  class LogicAction
+    def self.from_response(payload)
+      case payload[:action]
+      when 'jump'
+        LogicJump.from_response(payload)
+      when 'add', 'subtract', 'multiply', 'divide'
+        Calculation.from_response(payload)
+      end
     end
   end
 end

--- a/lib/create_api_gem/forms/logic/logic_condition.rb
+++ b/lib/create_api_gem/forms/logic/logic_condition.rb
@@ -15,71 +15,73 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class LogicCondition
-  attr_accessor :op, :vars
+module Typeform
+  class LogicCondition
+    attr_accessor :op, :vars
 
-  def initialize(op: nil, vars: [])
-    @op = op
-    @vars = vars
-  end
-
-  def vars_are_condition_details?
-    vars.is_a?(LogicConditionDetails)
-  end
-
-  def self.from_response(payload)
-    vars = []
-    if payload[:vars].any?
-      is_logic_condition_details = payload[:vars].detect { |var| var.key?(:op) }.nil?
-      vars = is_logic_condition_details ? [LogicConditionDetails.from_response(payload[:vars])] : payload[:vars].map { |condition_payload| LogicCondition.from_response(condition_payload) }
+    def initialize(op: nil, vars: [])
+      @op = op
+      @vars = vars
     end
-    LogicCondition.new(op: payload[:op], vars: vars)
-  end
 
-  def self.generate_from_block(block, op: nil)
-    case block.type
-    when :number, :opinion_scale, :rating
-      op ||= 'lower_equal_than'
-      logic_condition_details = LogicConditionDetails.new(reference_type: 'field', reference: block.ref, value_type: 'constant', value: 15)
-    when :date
-      op ||= 'not_on'
-      logic_condition_details = LogicConditionDetails.new(reference_type: 'field', reference: block.ref, value_type: 'constant', value: '2017-01-01')
-    when :yes_no, :legal
-      op ||= 'is'
-      logic_condition_details = LogicConditionDetails.new(reference_type: 'field', reference: block.ref, value_type: 'constant', value: true)
-    when :file_upload
-      op ||= 'answered'
-      logic_condition_details = LogicConditionDetails.new(reference_type: 'field', reference: block.ref, value_type: 'constant', value: true)
-    when :multiple_choice, :picture_choice
-      op ||= 'is'
-      logic_condition_details = LogicConditionDetails.new(reference_type: 'field', reference: block.ref, value_type: 'choice', value: block.choices.first.fetch(:ref))
-    else
-      op ||= 'contains'
-      logic_condition_details = LogicConditionDetails.new(reference_type: 'field', reference: block.ref, value_type: 'constant', value: 'hello')
+    def vars_are_condition_details?
+      vars.is_a?(LogicConditionDetails)
     end
-    LogicCondition.new(op: op, vars: [logic_condition_details])
-  end
 
-  def payload
-    payload = {}
-    payload[:op] = op
-    if vars.empty?
-      payload[:vars] = []
-    else
-      payload[:vars] = vars.map(&:payload)
-      payload[:vars].flatten!
+    def self.from_response(payload)
+      vars = []
+      if payload[:vars].any?
+        is_logic_condition_details = payload[:vars].detect { |var| var.key?(:op) }.nil?
+        vars = is_logic_condition_details ? [LogicConditionDetails.from_response(payload[:vars])] : payload[:vars].map { |condition_payload| LogicCondition.from_response(condition_payload) }
+      end
+      LogicCondition.new(op: payload[:op], vars: vars)
     end
-    payload
-  end
 
-  def same?(actual)
-    op == actual.op &&
-      same_vars?(actual.vars)
-  end
+    def self.generate_from_block(block, op: nil)
+      case block.type
+      when :number, :opinion_scale, :rating
+        op ||= 'lower_equal_than'
+        logic_condition_details = LogicConditionDetails.new(reference_type: 'field', reference: block.ref, value_type: 'constant', value: 15)
+      when :date
+        op ||= 'not_on'
+        logic_condition_details = LogicConditionDetails.new(reference_type: 'field', reference: block.ref, value_type: 'constant', value: '2017-01-01')
+      when :yes_no, :legal
+        op ||= 'is'
+        logic_condition_details = LogicConditionDetails.new(reference_type: 'field', reference: block.ref, value_type: 'constant', value: true)
+      when :file_upload
+        op ||= 'answered'
+        logic_condition_details = LogicConditionDetails.new(reference_type: 'field', reference: block.ref, value_type: 'constant', value: true)
+      when :multiple_choice, :picture_choice
+        op ||= 'is'
+        logic_condition_details = LogicConditionDetails.new(reference_type: 'field', reference: block.ref, value_type: 'choice', value: block.choices.first.fetch(:ref))
+      else
+        op ||= 'contains'
+        logic_condition_details = LogicConditionDetails.new(reference_type: 'field', reference: block.ref, value_type: 'constant', value: 'hello')
+      end
+      LogicCondition.new(op: op, vars: [logic_condition_details])
+    end
 
-  def same_vars?(actual_vars)
-    vars.zip(actual_vars).all? do |expected, actual|
-      expected.same?(actual)
+    def payload
+      payload = {}
+      payload[:op] = op
+      if vars.empty?
+        payload[:vars] = []
+      else
+        payload[:vars] = vars.map(&:payload)
+        payload[:vars].flatten!
+      end
+      payload
+    end
+
+    def same?(actual)
+      op == actual.op &&
+        same_vars?(actual.vars)
+    end
+
+    def same_vars?(actual_vars)
+      vars.zip(actual_vars).all? do |expected, actual|
+        expected.same?(actual)
+      end
     end
   end
 end

--- a/lib/create_api_gem/forms/logic/logic_condition_details.rb
+++ b/lib/create_api_gem/forms/logic/logic_condition_details.rb
@@ -15,43 +15,45 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class LogicConditionDetails
-  attr_accessor :reference_type, :reference, :value_type, :value
+module Typeform
+  class LogicConditionDetails
+    attr_accessor :reference_type, :reference, :value_type, :value
 
-  def initialize(reference_type: nil, reference: nil, value_type: nil, value: nil)
-    @reference_type = reference_type
-    @reference = reference
-    @value_type = value_type
-    @value = value
-  end
-
-  def self.from_response(payload)
-    reference_object = payload.first
-    value_object = payload.last
-    reference_type = reference_object[:type] unless reference_object.nil?
-    reference = reference_object[:value] unless reference_object.nil?
-    value_type = value_object[:type] unless value_object.nil?
-    value = value_object[:value] unless value_object.nil?
-    LogicConditionDetails.new(
-      reference_type: reference_type,
-      reference: reference,
-      value_type: value_type,
-      value: value
-    )
-  end
-
-  def payload
-    if reference_type.nil?
-      []
-    else
-      [{ type: reference_type, value: reference }, { type: value_type, value: value }]
+    def initialize(reference_type: nil, reference: nil, value_type: nil, value: nil)
+      @reference_type = reference_type
+      @reference = reference
+      @value_type = value_type
+      @value = value
     end
-  end
 
-  def same?(actual)
-    reference_type == actual.reference_type &&
-      reference == actual.reference &&
-      value_type == actual.value_type &&
-      value == actual.value
+    def self.from_response(payload)
+      reference_object = payload.first
+      value_object = payload.last
+      reference_type = reference_object[:type] unless reference_object.nil?
+      reference = reference_object[:value] unless reference_object.nil?
+      value_type = value_object[:type] unless value_object.nil?
+      value = value_object[:value] unless value_object.nil?
+      LogicConditionDetails.new(
+        reference_type: reference_type,
+        reference: reference,
+        value_type: value_type,
+        value: value
+      )
+    end
+
+    def payload
+      if reference_type.nil?
+        []
+      else
+        [{ type: reference_type, value: reference }, { type: value_type, value: value }]
+      end
+    end
+
+    def same?(actual)
+      reference_type == actual.reference_type &&
+        reference == actual.reference &&
+        value_type == actual.value_type &&
+        value == actual.value
+    end
   end
 end

--- a/lib/create_api_gem/forms/messages.rb
+++ b/lib/create_api_gem/forms/messages.rb
@@ -15,22 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class Messages
-  attr_accessor :messages
+module Typeform
+  class Messages
+    attr_accessor :messages
 
-  def initialize(messages)
-    @messages = Hash[messages.map { |(k, v)| [k.to_sym, v] }]
-  end
+    def initialize(messages)
+      @messages = Hash[messages.map { |(k, v)| [k.to_sym, v] }]
+    end
 
-  def self.from_response(response)
-    Messages.new(response)
-  end
+    def self.from_response(response)
+      Messages.new(response)
+    end
 
-  def payload
-    messages.to_json
-  end
+    def payload
+      messages.to_json
+    end
 
-  def same?(actual)
-    messages == actual.messages
+    def same?(actual)
+      messages == actual.messages
+    end
   end
 end

--- a/lib/create_api_gem/forms/requests/create_form_request.rb
+++ b/lib/create_api_gem/forms/requests/create_form_request.rb
@@ -17,19 +17,21 @@
 
 require_relative 'form_request'
 
-class CreateFormRequest < FormRequest
-  def initialize(form, token: APIConfig.token)
-    request(
-      method: :post,
-      url: "#{APIConfig.api_request_url}/forms",
-      headers: {
-        'Authorization' => "Bearer #{token}"
-      },
-      payload: form.payload
-    )
-  end
+module Typeform
+  class CreateFormRequest < FormRequest
+    def initialize(form, token: APIConfig.token)
+      request(
+        method: :post,
+        url: "#{APIConfig.api_request_url}/forms",
+        headers: {
+          'Authorization' => "Bearer #{token}"
+        },
+        payload: form.payload
+      )
+    end
 
-  def success?
-    @response.code == 201 && json?
+    def success?
+      @response.code == 201 && json?
+    end
   end
 end

--- a/lib/create_api_gem/forms/requests/delete_form_request.rb
+++ b/lib/create_api_gem/forms/requests/delete_form_request.rb
@@ -17,18 +17,20 @@
 
 require_relative 'form_request'
 
-class DeleteFormRequest < FormRequest
-  def initialize(form, token: APIConfig.token)
-    request(
-      method: :delete,
-      url: "#{APIConfig.api_request_url}/forms/#{form.id}",
-      headers: {
-        'Authorization' => "Bearer #{token}"
-      }
-    )
-  end
+module Typeform
+  class DeleteFormRequest < FormRequest
+    def initialize(form, token: APIConfig.token)
+      request(
+        method: :delete,
+        url: "#{APIConfig.api_request_url}/forms/#{form.id}",
+        headers: {
+          'Authorization' => "Bearer #{token}"
+        }
+      )
+    end
 
-  def success?
-    @response.code == 204
+    def success?
+      @response.code == 204
+    end
   end
 end

--- a/lib/create_api_gem/forms/requests/form_request.rb
+++ b/lib/create_api_gem/forms/requests/form_request.rb
@@ -17,44 +17,46 @@
 
 require_relative '../../api_request'
 
-class FormRequest < APIRequest
-  def form
-    Form.from_response(json)
-  end
+module Typeform
+  class FormRequest < APIRequest
+    def form
+      Form.from_response(json)
+    end
 
-  def error_code
-    json.fetch(:code)
-  end
+    def error_code
+      json.fetch(:code)
+    end
 
-  def invalid_form?
-    @response.code == 400 && %w[VALIDATION_ERROR BAD_REQUEST INVALID_JSON].include?(error_code)
-  end
+    def invalid_form?
+      @response.code == 400 && %w[VALIDATION_ERROR BAD_REQUEST INVALID_JSON].include?(error_code)
+    end
 
-  def unauthorized?
-    @response.code == 401
-  end
+    def unauthorized?
+      @response.code == 401
+    end
 
-  def payment_required?
-    @response.code == 402
-  end
+    def payment_required?
+      @response.code == 402
+    end
 
-  def forbidden?
-    @response.code == 403
-  end
+    def forbidden?
+      @response.code == 403
+    end
 
-  def not_found?
-    @response.code == 404
-  end
+    def not_found?
+      @response.code == 404
+    end
 
-  def conflict?
-    @response.code == 409
-  end
+    def conflict?
+      @response.code == 409
+    end
 
-  def service_unavailable?
-    @response.code == 502 || @response.code == 503
-  end
+    def service_unavailable?
+      @response.code == 502 || @response.code == 503
+    end
 
-  def last_modified
-    Time.parse(@response.headers[:last_modified])
+    def last_modified
+      Time.parse(@response.headers[:last_modified])
+    end
   end
 end

--- a/lib/create_api_gem/forms/requests/head_form_request.rb
+++ b/lib/create_api_gem/forms/requests/head_form_request.rb
@@ -17,18 +17,20 @@
 
 require_relative 'form_request'
 
-class HeadFormRequest < FormRequest
-  def initialize(form, token: APIConfig.token)
-    r = {
-      method: :head,
-      url: "#{APIConfig.api_request_url}/forms/#{form.id}"
-    }
-    r[:headers] = { 'Authorization' => "Bearer #{token}" } unless token.nil?
+module Typeform
+  class HeadFormRequest < FormRequest
+    def initialize(form, token: APIConfig.token)
+      r = {
+        method: :head,
+        url: "#{APIConfig.api_request_url}/forms/#{form.id}"
+      }
+      r[:headers] = { 'Authorization' => "Bearer #{token}" } unless token.nil?
 
-    request(r)
-  end
+      request(r)
+    end
 
-  def success?
-    @response.code == 200
+    def success?
+      @response.code == 200
+    end
   end
 end

--- a/lib/create_api_gem/forms/requests/messages/retrieve_messages_request.rb
+++ b/lib/create_api_gem/forms/requests/messages/retrieve_messages_request.rb
@@ -15,22 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class RetrieveMessagesRequest < APIRequest
-  def initialize(form, token: APIConfig.token)
-    request(
-      method: :get,
-      url: "#{APIConfig.api_request_url}/forms/#{form.id}/messages",
-      headers: {
-        'Authorization' => "Bearer #{token}"
-      }
-    )
-  end
+module Typeform
+  class RetrieveMessagesRequest < APIRequest
+    def initialize(form, token: APIConfig.token)
+      request(
+        method: :get,
+        url: "#{APIConfig.api_request_url}/forms/#{form.id}/messages",
+        headers: {
+          'Authorization' => "Bearer #{token}"
+        }
+      )
+    end
 
-  def success?
-    @response.code == 200 && json?
-  end
+    def success?
+      @response.code == 200 && json?
+    end
 
-  def messages
-    Messages.from_response(json)
+    def messages
+      Messages.from_response(json)
+    end
   end
 end

--- a/lib/create_api_gem/forms/requests/messages/update_messages_request.rb
+++ b/lib/create_api_gem/forms/requests/messages/update_messages_request.rb
@@ -15,23 +15,25 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class UpdateMessagesRequest < APIRequest
-  def initialize(form, messages, token: APIConfig.token)
-    request(
-      method: :put,
-      url: "#{APIConfig.api_request_url}/forms/#{form.id}/messages",
-      headers: {
-        'Authorization' => "Bearer #{token}"
-      },
-      payload: messages.payload
-    )
-  end
+module Typeform
+  class UpdateMessagesRequest < APIRequest
+    def initialize(form, messages, token: APIConfig.token)
+      request(
+        method: :put,
+        url: "#{APIConfig.api_request_url}/forms/#{form.id}/messages",
+        headers: {
+          'Authorization' => "Bearer #{token}"
+        },
+        payload: messages.payload
+      )
+    end
 
-  def success?
-    @response.code == 204
-  end
+    def success?
+      @response.code == 204
+    end
 
-  def payment_required?
-    @response.code == 402
+    def payment_required?
+      @response.code == 402
+    end
   end
 end

--- a/lib/create_api_gem/forms/requests/retrieve_all_forms_request.rb
+++ b/lib/create_api_gem/forms/requests/retrieve_all_forms_request.rb
@@ -18,29 +18,31 @@
 require_relative 'form_request'
 require 'open-uri'
 
-class RetrieveAllFormsRequest < FormRequest
-  def initialize(token: APIConfig.token, forms_per_page: 10, page: nil, search: nil, theme: nil, workspace: nil, from_id: nil)
-    url = "#{APIConfig.api_request_url}/forms?"
-    url << "page_size=#{forms_per_page}&" unless forms_per_page.nil?
-    url << "page=#{page}&" unless page.nil?
-    url << "search=#{URI.encode_www_form_component(search)}&" unless search.nil?
-    url << "theme_id=#{theme.id}&" unless theme.nil?
-    url << "workspace_id=#{workspace.id}&" unless workspace.nil?
-    url << "from_id=#{from_id}&" unless from_id.nil?
-    r = {
-      method: :get,
-      url: url
-    }
-    r[:headers] = { 'Authorization' => "Bearer #{token}" } unless token.nil?
+module Typeform
+  class RetrieveAllFormsRequest < FormRequest
+    def initialize(token: APIConfig.token, forms_per_page: 10, page: nil, search: nil, theme: nil, workspace: nil, from_id: nil)
+      url = "#{APIConfig.api_request_url}/forms?"
+      url << "page_size=#{forms_per_page}&" unless forms_per_page.nil?
+      url << "page=#{page}&" unless page.nil?
+      url << "search=#{URI.encode_www_form_component(search)}&" unless search.nil?
+      url << "theme_id=#{theme.id}&" unless theme.nil?
+      url << "workspace_id=#{workspace.id}&" unless workspace.nil?
+      url << "from_id=#{from_id}&" unless from_id.nil?
+      r = {
+        method: :get,
+        url: url
+      }
+      r[:headers] = { 'Authorization' => "Bearer #{token}" } unless token.nil?
 
-    request(r)
-  end
+      request(r)
+    end
 
-  def success?
-    @response.code == 200 && json?
-  end
+    def success?
+      @response.code == 200 && json?
+    end
 
-  def forms
-    json.fetch(:items)
+    def forms
+      json.fetch(:items)
+    end
   end
 end

--- a/lib/create_api_gem/forms/requests/retrieve_form_request.rb
+++ b/lib/create_api_gem/forms/requests/retrieve_form_request.rb
@@ -17,18 +17,20 @@
 
 require_relative 'form_request'
 
-class RetrieveFormRequest < FormRequest
-  def initialize(form, token: APIConfig.token)
-    r = {
-      method: :get,
-      url: "#{APIConfig.api_request_url}/forms/#{form.id}"
-    }
-    r[:headers] = { 'Authorization' => "Bearer #{token}" } unless token.nil?
+module Typeform
+  class RetrieveFormRequest < FormRequest
+    def initialize(form, token: APIConfig.token)
+      r = {
+        method: :get,
+        url: "#{APIConfig.api_request_url}/forms/#{form.id}"
+      }
+      r[:headers] = { 'Authorization' => "Bearer #{token}" } unless token.nil?
 
-    request(r)
-  end
+      request(r)
+    end
 
-  def success?
-    @response.code == 200 && json?
+    def success?
+      @response.code == 200 && json?
+    end
   end
 end

--- a/lib/create_api_gem/forms/requests/update_form_patch_request.rb
+++ b/lib/create_api_gem/forms/requests/update_form_patch_request.rb
@@ -17,20 +17,22 @@
 
 require_relative 'form_request'
 
-class UpdateFormPatchRequest < FormRequest
-  def initialize(form, operations, token: APIConfig.token)
-    request(
-      method: :patch,
-      url: "#{APIConfig.api_request_url}/forms/#{form.id}",
-      headers: {
-        'Authorization' => "Bearer #{token}",
-        'Content-Type' => 'application/json'
-      },
-      payload: operations.map(&:payload).to_json
-    )
-  end
+module Typeform
+  class UpdateFormPatchRequest < FormRequest
+    def initialize(form, operations, token: APIConfig.token)
+      request(
+        method: :patch,
+        url: "#{APIConfig.api_request_url}/forms/#{form.id}",
+        headers: {
+          'Authorization' => "Bearer #{token}",
+          'Content-Type' => 'application/json'
+        },
+        payload: operations.map(&:payload).to_json
+      )
+    end
 
-  def success?
-    @response.code == 204
+    def success?
+      @response.code == 204
+    end
   end
 end

--- a/lib/create_api_gem/forms/requests/update_form_request.rb
+++ b/lib/create_api_gem/forms/requests/update_form_request.rb
@@ -17,19 +17,21 @@
 
 require_relative 'form_request'
 
-class UpdateFormRequest < FormRequest
-  def initialize(form, token: APIConfig.token)
-    request(
-      method: :put,
-      url: "#{APIConfig.api_request_url}/forms/#{form.id}",
-      headers: {
-        'Authorization' => "Bearer #{token}"
-      },
-      payload: form.payload
-    )
-  end
+module Typeform
+  class UpdateFormRequest < FormRequest
+    def initialize(form, token: APIConfig.token)
+      request(
+        method: :put,
+        url: "#{APIConfig.api_request_url}/forms/#{form.id}",
+        headers: {
+          'Authorization' => "Bearer #{token}"
+        },
+        payload: form.payload
+      )
+    end
 
-  def success?
-    @response.code == 200 && json?
+    def success?
+      @response.code == 200 && json?
+    end
   end
 end

--- a/lib/create_api_gem/forms/settings/notifications.rb
+++ b/lib/create_api_gem/forms/settings/notifications.rb
@@ -15,85 +15,87 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class Notifications
-  attr_accessor :self_enabled, :self_recipients, :self_reply_to, :self_subject, :self_message,
-                :respondent_enabled, :respondent_recipient, :respondent_reply_to, :respondent_subject, :respondent_message
+module Typeform
+  class Notifications
+    attr_accessor :self_enabled, :self_recipients, :self_reply_to, :self_subject, :self_message,
+                  :respondent_enabled, :respondent_recipient, :respondent_reply_to, :respondent_subject, :respondent_message
 
-  def initialize(self_enabled: nil, self_recipients: nil, self_reply_to: nil, self_subject: nil, self_message: nil,
-                 respondent_enabled: nil, respondent_recipient: nil, respondent_reply_to: nil, respondent_subject: nil, respondent_message: nil)
-    @self_enabled = self_enabled
-    @self_recipients = self_recipients
-    @self_reply_to = self_reply_to
-    @self_subject = self_subject
-    @self_message = self_message
-    @respondent_enabled = respondent_enabled
-    @respondent_recipient = respondent_recipient
-    @respondent_reply_to = respondent_reply_to
-    @respondent_subject = respondent_subject
-    @respondent_message = respondent_message
-  end
+    def initialize(self_enabled: nil, self_recipients: nil, self_reply_to: nil, self_subject: nil, self_message: nil,
+                  respondent_enabled: nil, respondent_recipient: nil, respondent_reply_to: nil, respondent_subject: nil, respondent_message: nil)
+      @self_enabled = self_enabled
+      @self_recipients = self_recipients
+      @self_reply_to = self_reply_to
+      @self_subject = self_subject
+      @self_message = self_message
+      @respondent_enabled = respondent_enabled
+      @respondent_recipient = respondent_recipient
+      @respondent_reply_to = respondent_reply_to
+      @respondent_subject = respondent_subject
+      @respondent_message = respondent_message
+    end
 
-  def self.from_response(response)
-    self_payload = response[:self]
-    new_self_payload = {}
-    if self_payload
-      self_payload.each_key do |key|
-        new_key = 'self_' + key.to_s
-        new_self_payload[new_key.to_sym] = self_payload.delete(key)
+    def self.from_response(response)
+      self_payload = response[:self]
+      new_self_payload = {}
+      if self_payload
+        self_payload.each_key do |key|
+          new_key = 'self_' + key.to_s
+          new_self_payload[new_key.to_sym] = self_payload.delete(key)
+        end
       end
-    end
 
-    respondent_payload = response[:respondent]
-    new_respondent_payload = {}
-    if respondent_payload
-      respondent_payload.each_key do |key|
-        new_key = 'respondent_' + key.to_s
-        new_respondent_payload[new_key.to_sym] = respondent_payload.delete(key)
+      respondent_payload = response[:respondent]
+      new_respondent_payload = {}
+      if respondent_payload
+        respondent_payload.each_key do |key|
+          new_key = 'respondent_' + key.to_s
+          new_respondent_payload[new_key.to_sym] = respondent_payload.delete(key)
+        end
       end
+
+      params = new_respondent_payload.merge(new_self_payload)
+      Notifications.new(params)
     end
 
-    params = new_respondent_payload.merge(new_self_payload)
-    Notifications.new(params)
-  end
-
-  def payload
-    payload = {}
-    unless self_recipients.nil? && self_subject.nil? && self_message.nil?
-      payload[:self] = {}
-      payload[:self][:enabled] = self_enabled unless self_enabled.nil?
-      payload[:self][:reply_to] = self_reply_to unless self_reply_to.nil?
-      payload[:self][:recipients] = self_recipients unless self_recipients.nil?
-      payload[:self][:subject] = self_subject unless self_subject.nil?
-      payload[:self][:message] = self_message unless self_message.nil?
+    def payload
+      payload = {}
+      unless self_recipients.nil? && self_subject.nil? && self_message.nil?
+        payload[:self] = {}
+        payload[:self][:enabled] = self_enabled unless self_enabled.nil?
+        payload[:self][:reply_to] = self_reply_to unless self_reply_to.nil?
+        payload[:self][:recipients] = self_recipients unless self_recipients.nil?
+        payload[:self][:subject] = self_subject unless self_subject.nil?
+        payload[:self][:message] = self_message unless self_message.nil?
+      end
+      unless respondent_recipient.nil? && respondent_subject.nil? && respondent_message.nil?
+        payload[:respondent] = {}
+        payload[:respondent][:enabled] = respondent_enabled unless respondent_enabled.nil?
+        payload[:respondent][:reply_to] = respondent_reply_to unless respondent_reply_to.nil?
+        payload[:respondent][:recipient] = respondent_recipient unless respondent_recipient.nil?
+        payload[:respondent][:subject] = respondent_subject unless respondent_subject.nil?
+        payload[:respondent][:message] = respondent_message unless respondent_message.nil?
+      end
+      payload
     end
-    unless respondent_recipient.nil? && respondent_subject.nil? && respondent_message.nil?
-      payload[:respondent] = {}
-      payload[:respondent][:enabled] = respondent_enabled unless respondent_enabled.nil?
-      payload[:respondent][:reply_to] = respondent_reply_to unless respondent_reply_to.nil?
-      payload[:respondent][:recipient] = respondent_recipient unless respondent_recipient.nil?
-      payload[:respondent][:subject] = respondent_subject unless respondent_subject.nil?
-      payload[:respondent][:message] = respondent_message unless respondent_message.nil?
+
+    def same?(actual)
+      (self_enabled.nil? || self_enabled == actual.self_enabled) &&
+        (self_reply_to.nil? || self_reply_to == actual.self_reply_to) &&
+        (self_recipients.nil? || self_recipients == actual.self_recipients) &&
+        (self_subject.nil? || self_subject == actual.self_subject) &&
+        (self_message.nil? || self_message == actual.self_message) &&
+        (respondent_enabled.nil? || respondent_enabled == actual.respondent_enabled) &&
+        (respondent_reply_to.nil? || respondent_reply_to == actual.respondent_reply_to) &&
+        (respondent_recipient.nil? || respondent_recipient == actual.respondent_recipient) &&
+        (respondent_subject.nil? || respondent_subject == actual.respondent_subject) &&
+        (respondent_message.nil? || respondent_message == actual.respondent_message)
     end
-    payload
-  end
 
-  def same?(actual)
-    (self_enabled.nil? || self_enabled == actual.self_enabled) &&
-      (self_reply_to.nil? || self_reply_to == actual.self_reply_to) &&
-      (self_recipients.nil? || self_recipients == actual.self_recipients) &&
-      (self_subject.nil? || self_subject == actual.self_subject) &&
-      (self_message.nil? || self_message == actual.self_message) &&
-      (respondent_enabled.nil? || respondent_enabled == actual.respondent_enabled) &&
-      (respondent_reply_to.nil? || respondent_reply_to == actual.respondent_reply_to) &&
-      (respondent_recipient.nil? || respondent_recipient == actual.respondent_recipient) &&
-      (respondent_subject.nil? || respondent_subject == actual.respondent_subject) &&
-      (respondent_message.nil? || respondent_message == actual.respondent_message)
-  end
-
-  def self.full_example(email_block_for_notifications_ref)
-    Notifications.new(self_enabled: true, self_reply_to: '{{field:' + email_block_for_notifications_ref + '}}', self_recipients: ['recipient1@email.com', 'recipient2@email.com'],
-                      self_subject: 'An email subject', self_message: 'This is a message that will be in an email',
-                      respondent_enabled: true, respondent_reply_to: ['hello@email.com'], respondent_recipient: '{{field:' + email_block_for_notifications_ref + '}}',
-                      respondent_subject: 'An email subject', respondent_message: 'This is a message that will be in an email')
+    def self.full_example(email_block_for_notifications_ref)
+      Notifications.new(self_enabled: true, self_reply_to: '{{field:' + email_block_for_notifications_ref + '}}', self_recipients: ['recipient1@email.com', 'recipient2@email.com'],
+                        self_subject: 'An email subject', self_message: 'This is a message that will be in an email',
+                        respondent_enabled: true, respondent_reply_to: ['hello@email.com'], respondent_recipient: '{{field:' + email_block_for_notifications_ref + '}}',
+                        respondent_subject: 'An email subject', respondent_message: 'This is a message that will be in an email')
+    end
   end
 end

--- a/lib/create_api_gem/forms/settings/settings.rb
+++ b/lib/create_api_gem/forms/settings/settings.rb
@@ -15,91 +15,93 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class Settings
-  attr_accessor :redirect_after_submit_url, :show_typeform_branding, :progress_bar,
-                :show_progress_bar, :description, :allow_indexing, :image, :language,
-                :is_public, :is_trial, :google_analytics, :facebook_pixel, :google_tag_manager,
-                :notifications
+module Typeform
+  class Settings
+    attr_accessor :redirect_after_submit_url, :show_typeform_branding, :progress_bar,
+                  :show_progress_bar, :description, :allow_indexing, :image, :language,
+                  :is_public, :is_trial, :google_analytics, :facebook_pixel, :google_tag_manager,
+                  :notifications
 
-  def initialize(redirect_after_submit_url: nil, show_typeform_branding: nil, progress_bar: nil,
-                 show_progress_bar: nil, description: nil, allow_indexing: nil, image: nil, language: nil,
-                 is_public: nil, is_trial: nil, google_analytics: nil, facebook_pixel: nil,
-                 google_tag_manager: nil, notifications: nil)
+    def initialize(redirect_after_submit_url: nil, show_typeform_branding: nil, progress_bar: nil,
+                  show_progress_bar: nil, description: nil, allow_indexing: nil, image: nil, language: nil,
+                  is_public: nil, is_trial: nil, google_analytics: nil, facebook_pixel: nil,
+                  google_tag_manager: nil, notifications: nil)
 
-    @redirect_after_submit_url = redirect_after_submit_url
-    @show_typeform_branding = show_typeform_branding
-    @progress_bar = progress_bar
-    @show_progress_bar = show_progress_bar
-    @description = description
-    @allow_indexing = allow_indexing
-    @language = language
-    @is_public = is_public
-    @is_trial = is_trial
-    @image = image
-    @google_analytics = google_analytics
-    @facebook_pixel = facebook_pixel
-    @google_tag_manager = google_tag_manager
-    @notifications = notifications
-  end
-
-  def self.from_response(response)
-    meta = response[:meta]
-    settings_params = response.keep_if { |k, _| k != :meta }
-    params = meta.merge(settings_params)
-    params[:notifications] = Notifications.from_response(response[:notifications]) unless response[:notifications].nil?
-    Settings.new(params)
-  end
-
-  def payload
-    payload = {}
-    payload[:redirect_after_submit_url] = redirect_after_submit_url unless redirect_after_submit_url.nil?
-    payload[:show_typeform_branding] = show_typeform_branding unless show_typeform_branding.nil?
-    payload[:progress_bar] = progress_bar unless progress_bar.nil?
-    payload[:show_progress_bar] = show_progress_bar unless show_progress_bar.nil?
-    payload[:language] = language unless language.nil?
-    payload[:is_public] = is_public unless is_public.nil?
-    payload[:google_analytics] = google_analytics unless google_analytics.nil?
-    payload[:facebook_pixel] = facebook_pixel unless facebook_pixel.nil?
-    payload[:google_tag_manager] = google_tag_manager unless google_tag_manager.nil?
-    payload[:notifications] = notifications.payload unless notifications.nil?
-    unless description.nil? && allow_indexing.nil?
-      payload[:meta] = {}
-      payload[:meta][:description] = description unless description.nil?
-      payload[:meta][:allow_indexing] = allow_indexing unless allow_indexing.nil?
-      payload[:meta][:image] = image unless image.nil?
+      @redirect_after_submit_url = redirect_after_submit_url
+      @show_typeform_branding = show_typeform_branding
+      @progress_bar = progress_bar
+      @show_progress_bar = show_progress_bar
+      @description = description
+      @allow_indexing = allow_indexing
+      @language = language
+      @is_public = is_public
+      @is_trial = is_trial
+      @image = image
+      @google_analytics = google_analytics
+      @facebook_pixel = facebook_pixel
+      @google_tag_manager = google_tag_manager
+      @notifications = notifications
     end
-    payload
-  end
 
-  def same?(actual)
-    (redirect_after_submit_url.nil? || redirect_after_submit_url == actual.redirect_after_submit_url) &&
-      (google_analytics.nil? || google_analytics == actual.google_analytics) &&
-      (facebook_pixel.nil? || facebook_pixel == actual.facebook_pixel) &&
-      (google_tag_manager.nil? || google_tag_manager == actual.google_tag_manager) &&
-      (notifications.nil? || notifications.same?(actual.notifications)) &&
-      (description.nil? || description == actual.description) &&
-      (show_typeform_branding.nil? ? Settings.default.show_typeform_branding : show_typeform_branding) == actual.show_typeform_branding &&
-      (progress_bar.nil? ? Settings.default.progress_bar : progress_bar) == actual.progress_bar &&
-      (language.nil? ? Settings.default.language : language) == actual.language &&
-      (is_public.nil? ? Settings.default.is_public : is_public) == actual.is_public &&
-      (allow_indexing.nil? ? Settings.default.allow_indexing : allow_indexing) == actual.allow_indexing &&
-      same_image?(actual)
-  end
+    def self.from_response(response)
+      meta = response[:meta]
+      settings_params = response.keep_if { |k, _| k != :meta }
+      params = meta.merge(settings_params)
+      params[:notifications] = Notifications.from_response(response[:notifications]) unless response[:notifications].nil?
+      Settings.new(params)
+    end
 
-  def same_image?(actual)
-    image.nil? || image[:href].start_with?("#{APIConfig.image_api_request_url}/images/") && actual.image[:href].start_with?("#{APIConfig.image_api_request_url}/images/")
-  end
+    def payload
+      payload = {}
+      payload[:redirect_after_submit_url] = redirect_after_submit_url unless redirect_after_submit_url.nil?
+      payload[:show_typeform_branding] = show_typeform_branding unless show_typeform_branding.nil?
+      payload[:progress_bar] = progress_bar unless progress_bar.nil?
+      payload[:show_progress_bar] = show_progress_bar unless show_progress_bar.nil?
+      payload[:language] = language unless language.nil?
+      payload[:is_public] = is_public unless is_public.nil?
+      payload[:google_analytics] = google_analytics unless google_analytics.nil?
+      payload[:facebook_pixel] = facebook_pixel unless facebook_pixel.nil?
+      payload[:google_tag_manager] = google_tag_manager unless google_tag_manager.nil?
+      payload[:notifications] = notifications.payload unless notifications.nil?
+      unless description.nil? && allow_indexing.nil?
+        payload[:meta] = {}
+        payload[:meta][:description] = description unless description.nil?
+        payload[:meta][:allow_indexing] = allow_indexing unless allow_indexing.nil?
+        payload[:meta][:image] = image unless image.nil?
+      end
+      payload
+    end
 
-  def self.default
-    Settings.new(show_typeform_branding: true, progress_bar: 'proportion', show_progress_bar: true,
-                 allow_indexing: false, language: 'en', is_public: true, is_trial: false)
-  end
+    def same?(actual)
+      (redirect_after_submit_url.nil? || redirect_after_submit_url == actual.redirect_after_submit_url) &&
+        (google_analytics.nil? || google_analytics == actual.google_analytics) &&
+        (facebook_pixel.nil? || facebook_pixel == actual.facebook_pixel) &&
+        (google_tag_manager.nil? || google_tag_manager == actual.google_tag_manager) &&
+        (notifications.nil? || notifications.same?(actual.notifications)) &&
+        (description.nil? || description == actual.description) &&
+        (show_typeform_branding.nil? ? Settings.default.show_typeform_branding : show_typeform_branding) == actual.show_typeform_branding &&
+        (progress_bar.nil? ? Settings.default.progress_bar : progress_bar) == actual.progress_bar &&
+        (language.nil? ? Settings.default.language : language) == actual.language &&
+        (is_public.nil? ? Settings.default.is_public : is_public) == actual.is_public &&
+        (allow_indexing.nil? ? Settings.default.allow_indexing : allow_indexing) == actual.allow_indexing &&
+        same_image?(actual)
+    end
 
-  def self.full_example(email_block_for_notifications_ref)
-    image = { href: APIConfig.image_api_request_url + '/images/default' }
-    Settings.new(redirect_after_submit_url: 'http://google.com', show_typeform_branding: false, progress_bar: 'percentage',
-                 show_progress_bar: false, description: 'some meta description', allow_indexing: true, image: image,
-                 language: 'fr', is_public: true, google_analytics: 'UA-1234-12', facebook_pixel: '12345678901234567',
-                 google_tag_manager: 'GTM-PLWP6TS', notifications: Notifications.full_example(email_block_for_notifications_ref))
+    def same_image?(actual)
+      image.nil? || image[:href].start_with?("#{APIConfig.image_api_request_url}/images/") && actual.image[:href].start_with?("#{APIConfig.image_api_request_url}/images/")
+    end
+
+    def self.default
+      Settings.new(show_typeform_branding: true, progress_bar: 'proportion', show_progress_bar: true,
+                  allow_indexing: false, language: 'en', is_public: true, is_trial: false)
+    end
+
+    def self.full_example(email_block_for_notifications_ref)
+      image = { href: APIConfig.image_api_request_url + '/images/default' }
+      Settings.new(redirect_after_submit_url: 'http://google.com', show_typeform_branding: false, progress_bar: 'percentage',
+                  show_progress_bar: false, description: 'some meta description', allow_indexing: true, image: image,
+                  language: 'fr', is_public: true, google_analytics: 'UA-1234-12', facebook_pixel: '12345678901234567',
+                  google_tag_manager: 'GTM-PLWP6TS', notifications: Notifications.full_example(email_block_for_notifications_ref))
+    end
   end
 end

--- a/lib/create_api_gem/forms/variables.rb
+++ b/lib/create_api_gem/forms/variables.rb
@@ -15,38 +15,40 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class Variables
-  attr_accessor :price, :score
+module Typeform
+  class Variables
+    attr_accessor :price, :score
 
-  def initialize(price: nil, score: nil)
-    @price = price
-    @score = score
-  end
+    def initialize(price: nil, score: nil)
+      @price = price
+      @score = score
+    end
 
-  def self.from_response(payload)
-    new(
-      price: payload[:price],
-      score: payload[:score]
-    )
-  end
+    def self.from_response(payload)
+      new(
+        price: payload[:price],
+        score: payload[:score]
+      )
+    end
 
-  def self.default
-    Variables.new
-  end
+    def self.default
+      Variables.new
+    end
 
-  def self.full_example
-    Variables.new(price: 10, score: 0)
-  end
+    def self.full_example
+      Variables.new(price: 10, score: 0)
+    end
 
-  def payload
-    payload = {}
-    payload[:score] = score unless score.nil?
-    payload[:price] = price unless price.nil?
-    payload
-  end
+    def payload
+      payload = {}
+      payload[:score] = score unless score.nil?
+      payload[:price] = price unless price.nil?
+      payload
+    end
 
-  def same?(actual)
-    (score.nil? || score == actual.score) &&
-      (price.nil? || price == actual.price)
+    def same?(actual)
+      (score.nil? || score == actual.score) &&
+        (price.nil? || price == actual.price)
+    end
   end
 end

--- a/lib/create_api_gem/images/image.rb
+++ b/lib/create_api_gem/images/image.rb
@@ -15,63 +15,65 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class Image
-  attr_accessor :id, :image, :media_type, :file_name, :width, :height, :has_alpha, :avg_color
+module Typeform
+  class Image
+    attr_accessor :id, :image, :media_type, :file_name, :width, :height, :has_alpha, :avg_color
 
-  def initialize(id: nil, image: nil, media_type: nil, file_name: nil, width: nil, height: nil, has_alpha: nil, avg_color: nil)
-    @id = id
-    @image = image
-    @media_type = media_type
-    @file_name = file_name
-    @width = width
-    @height = height
-    @has_alpha = has_alpha
-    @avg_color = avg_color
-  end
+    def initialize(id: nil, image: nil, media_type: nil, file_name: nil, width: nil, height: nil, has_alpha: nil, avg_color: nil)
+      @id = id
+      @image = image
+      @media_type = media_type
+      @file_name = file_name
+      @width = width
+      @height = height
+      @has_alpha = has_alpha
+      @avg_color = avg_color
+    end
 
-  def self.from_response(payload)
-    Image.new(
-      id: payload[:id],
-      media_type: payload[:media_type],
-      file_name: payload[:file_name],
-      width: payload[:width],
-      height: payload[:height],
-      has_alpha: payload[:has_alpha],
-      avg_color: payload[:avg_color]
-    )
-  end
+    def self.from_response(payload)
+      Image.new(
+        id: payload[:id],
+        media_type: payload[:media_type],
+        file_name: payload[:file_name],
+        width: payload[:width],
+        height: payload[:height],
+        has_alpha: payload[:has_alpha],
+        avg_color: payload[:avg_color]
+      )
+    end
 
-  def payload
-    {
-      image: image,
-      media_type: media_type,
-      file_name: file_name
-    }.to_json
-  end
+    def payload
+      {
+        image: image,
+        media_type: media_type,
+        file_name: file_name
+      }.to_json
+    end
 
-  def same?(actual)
-    (id.nil? || id == actual.id) &&
-      (media_type.nil? || media_type == actual.media_type) &&
-      (file_name.nil? || file_name == actual.file_name) &&
-      (width.nil? || width == actual.width) &&
-      (height.nil? || height == actual.height) &&
-      (has_alpha.nil? || has_alpha == actual.has_alpha) &&
-      (avg_color.nil? || avg_color == actual.avg_color)
-  end
+    def same?(actual)
+      (id.nil? || id == actual.id) &&
+        (media_type.nil? || media_type == actual.media_type) &&
+        (file_name.nil? || file_name == actual.file_name) &&
+        (width.nil? || width == actual.width) &&
+        (height.nil? || height == actual.height) &&
+        (has_alpha.nil? || has_alpha == actual.has_alpha) &&
+        (avg_color.nil? || avg_color == actual.avg_color)
+    end
 
-  def src
-    "#{APIConfig.image_api_request_url}/images/#{id}"
-  end
+    def src
+      "#{APIConfig.image_api_request_url}/images/#{id}"
+    end
 
-  def self.full_example
-    Image.new(
-      image: File.read(File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'data', 'typeform_image.txt'))),
-      media_type: 'image/gif',
-      file_name: 'typeform.gif',
-      width: 530,
-      height: 350,
-      has_alpha: true,
-      avg_color: '5a6067'
-    )
+    def self.full_example
+      Image.new(
+        image: File.read(File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'data', 'typeform_image.txt'))),
+        media_type: 'image/gif',
+        file_name: 'typeform.gif',
+        width: 530,
+        height: 350,
+        has_alpha: true,
+        avg_color: '5a6067'
+      )
+    end
   end
 end

--- a/lib/create_api_gem/images/requests/create_image_from_url_request.rb
+++ b/lib/create_api_gem/images/requests/create_image_from_url_request.rb
@@ -17,22 +17,24 @@
 
 require_relative 'image_request'
 
-class CreateImageFromUrlRequest < ImageRequest
-  def initialize(image_url, token: APIConfig.token)
-    request(
-      method: :post,
-      url: "#{APIConfig.api_request_url}/images",
-      headers: {
-        'Content-Type' => 'application/json',
-        'Authorization' => "Bearer #{token}"
-      },
-      payload: {
-        url: image_url
-      }.to_json
-    )
-  end
+module Typeform
+  class CreateImageFromUrlRequest < ImageRequest
+    def initialize(image_url, token: APIConfig.token)
+      request(
+        method: :post,
+        url: "#{APIConfig.api_request_url}/images",
+        headers: {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Bearer #{token}"
+        },
+        payload: {
+          url: image_url
+        }.to_json
+      )
+    end
 
-  def success?
-    @response.code == 201 && json?
+    def success?
+      @response.code == 201 && json?
+    end
   end
 end

--- a/lib/create_api_gem/images/requests/create_image_request.rb
+++ b/lib/create_api_gem/images/requests/create_image_request.rb
@@ -17,20 +17,22 @@
 
 require_relative 'image_request'
 
-class CreateImageRequest < ImageRequest
-  def initialize(image, token: APIConfig.token)
-    request(
-      method: :post,
-      url: "#{APIConfig.api_request_url}/images",
-      headers: {
-        'Content-Type' => 'application/json',
-        'Authorization' => "Bearer #{token}"
-      },
-      payload: image.payload
-    )
-  end
+module Typeform
+  class CreateImageRequest < ImageRequest
+    def initialize(image, token: APIConfig.token)
+      request(
+        method: :post,
+        url: "#{APIConfig.api_request_url}/images",
+        headers: {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Bearer #{token}"
+        },
+        payload: image.payload
+      )
+    end
 
-  def success?
-    @response.code == 201 && json?
+    def success?
+      @response.code == 201 && json?
+    end
   end
 end

--- a/lib/create_api_gem/images/requests/delete_image_request.rb
+++ b/lib/create_api_gem/images/requests/delete_image_request.rb
@@ -17,19 +17,21 @@
 
 require_relative 'image_request'
 
-class DeleteImageRequest < ImageRequest
-  def initialize(image, token: APIConfig.token)
-    request(
-      method: :delete,
-      url: "#{APIConfig.api_request_url}/images/#{image.id}",
-      headers: {
-        'Content-Type' => 'application/json',
-        'Authorization' => "Bearer #{token}"
-      }
-    )
-  end
+module Typeform
+  class DeleteImageRequest < ImageRequest
+    def initialize(image, token: APIConfig.token)
+      request(
+        method: :delete,
+        url: "#{APIConfig.api_request_url}/images/#{image.id}",
+        headers: {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Bearer #{token}"
+        }
+      )
+    end
 
-  def success?
-    @response.code == 204
+    def success?
+      @response.code == 204
+    end
   end
 end

--- a/lib/create_api_gem/images/requests/image_request.rb
+++ b/lib/create_api_gem/images/requests/image_request.rb
@@ -17,12 +17,14 @@
 
 require_relative '../../api_request'
 
-class ImageRequest < APIRequest
-  def image
-    Image.from_response(json)
-  end
+module Typeform
+  class ImageRequest < APIRequest
+    def image
+      Image.from_response(json)
+    end
 
-  def src
-    json.fetch(:src)
+    def src
+      json.fetch(:src)
+    end
   end
 end

--- a/lib/create_api_gem/images/requests/retrieve_all_images_request.rb
+++ b/lib/create_api_gem/images/requests/retrieve_all_images_request.rb
@@ -17,23 +17,25 @@
 
 require_relative 'image_request'
 
-class RetrieveAllImagesRequest < ImageRequest
-  def initialize(token: APIConfig.token)
-    request(
-      method: :get,
-      url: "#{APIConfig.api_request_url}/images",
-      headers: {
-        'Content-Type' => 'application/json',
-        'Authorization' => "Bearer #{token}"
-      }
-    )
-  end
+module Typeform
+  class RetrieveAllImagesRequest < ImageRequest
+    def initialize(token: APIConfig.token)
+      request(
+        method: :get,
+        url: "#{APIConfig.api_request_url}/images",
+        headers: {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Bearer #{token}"
+        }
+      )
+    end
 
-  def images
-    json.map { |image| Image.from_response(image) }
-  end
+    def images
+      json.map { |image| Image.from_response(image) }
+    end
 
-  def success?
-    @response.code == 200 && json?
+    def success?
+      @response.code == 200 && json?
+    end
   end
 end

--- a/lib/create_api_gem/images/requests/retrieve_frame_request.rb
+++ b/lib/create_api_gem/images/requests/retrieve_frame_request.rb
@@ -17,18 +17,20 @@
 
 require_relative 'image_request'
 
-class RetrieveFrameRequest < ImageRequest
-  def initialize(image, frame)
-    request(
-      method: :get,
-      url: "#{APIConfig.image_api_request_url}/images/#{image.id}/image/default-#{frame}frame.png",
-      headers: {
-        'Content-Type' => 'application/json'
-      }
-    )
-  end
+module Typeform
+  class RetrieveFrameRequest < ImageRequest
+    def initialize(image, frame)
+      request(
+        method: :get,
+        url: "#{APIConfig.image_api_request_url}/images/#{image.id}/image/default-#{frame}frame.png",
+        headers: {
+          'Content-Type' => 'application/json'
+        }
+      )
+    end
 
-  def success?
-    @response.code == 200
+    def success?
+      @response.code == 200
+    end
   end
 end

--- a/lib/create_api_gem/images/requests/retrieve_image_request.rb
+++ b/lib/create_api_gem/images/requests/retrieve_image_request.rb
@@ -17,27 +17,29 @@
 
 require_relative 'image_request'
 
-class RetrieveImageRequest < ImageRequest
-  def initialize(image, type: nil, size: nil, accept: nil)
-    url = if type.nil? && size.nil?
-            "#{APIConfig.api_request_url}/images/#{image.id}"
-          else
-            "#{APIConfig.api_request_url}/images/#{image.id}/#{type}/#{size}"
-          end
-    headers = { 'Content-Type' => 'application/json' }
-    headers['Accept'] = 'application/json' if accept == 'json'
-    request(
-      method: :get,
-      url: url,
-      headers: headers
-    )
-  end
+module Typeform
+  class RetrieveImageRequest < ImageRequest
+    def initialize(image, type: nil, size: nil, accept: nil)
+      url = if type.nil? && size.nil?
+              "#{APIConfig.api_request_url}/images/#{image.id}"
+            else
+              "#{APIConfig.api_request_url}/images/#{image.id}/#{type}/#{size}"
+            end
+      headers = { 'Content-Type' => 'application/json' }
+      headers['Accept'] = 'application/json' if accept == 'json'
+      request(
+        method: :get,
+        url: url,
+        headers: headers
+      )
+    end
 
-  def success?
-    @response.code == 200
-  end
+    def success?
+      @response.code == 200
+    end
 
-  def body
-    @response.body
+    def body
+      @response.body
+    end
   end
 end

--- a/lib/create_api_gem/patch_operation.rb
+++ b/lib/create_api_gem/patch_operation.rb
@@ -15,20 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class PatchOperation
-  attr_accessor :op, :value, :path
+module Typeform
+  class PatchOperation
+    attr_accessor :op, :value, :path
 
-  def initialize(op: nil, path: nil, value: nil)
-    @op = op
-    @path = path
-    @value = value
-  end
+    def initialize(op: nil, path: nil, value: nil)
+      @op = op
+      @path = path
+      @value = value
+    end
 
-  def payload
-    {
-      op: op,
-      path: path,
-      value: value
-    }
+    def payload
+      {
+        op: op,
+        path: path,
+        value: value
+      }
+    end
   end
 end

--- a/lib/create_api_gem/teams/requests/retrieve_team_request.rb
+++ b/lib/create_api_gem/teams/requests/retrieve_team_request.rb
@@ -17,18 +17,20 @@
 
 require_relative 'team_request'
 
-class RetrieveTeamRequest < TeamRequest
-  def initialize(token: APIConfig.token)
-    request(
-      method: :get,
-      url: "#{APIConfig.api_request_url}/teams/mine",
-      headers: {
-        'Authorization' => "Bearer #{token}"
-      }
-    )
-  end
+module Typeform
+  class RetrieveTeamRequest < TeamRequest
+    def initialize(token: APIConfig.token)
+      request(
+        method: :get,
+        url: "#{APIConfig.api_request_url}/teams/mine",
+        headers: {
+          'Authorization' => "Bearer #{token}"
+        }
+      )
+    end
 
-  def success?
-    @response.code == 200 && json? && json.key?(:members) && json.key?(:total_seats)
+    def success?
+      @response.code == 200 && json? && json.key?(:members) && json.key?(:total_seats)
+    end
   end
 end

--- a/lib/create_api_gem/teams/requests/team_request.rb
+++ b/lib/create_api_gem/teams/requests/team_request.rb
@@ -17,20 +17,22 @@
 
 require_relative '../../api_request'
 
-class TeamRequest < APIRequest
-  def not_found?
-    @response.code == 404
-  end
+module Typeform
+  class TeamRequest < APIRequest
+    def not_found?
+      @response.code == 404
+    end
 
-  def forbidden?
-    @response.code == 403
-  end
+    def forbidden?
+      @response.code == 403
+    end
 
-  def bad_request?
-    @response.code == 400
-  end
+    def bad_request?
+      @response.code == 400
+    end
 
-  def payment_required?
-    @response.code == 402
+    def payment_required?
+      @response.code == 402
+    end
   end
 end

--- a/lib/create_api_gem/teams/requests/update_team_request.rb
+++ b/lib/create_api_gem/teams/requests/update_team_request.rb
@@ -17,19 +17,21 @@
 
 require_relative 'team_request'
 
-class UpdateTeamRequest < TeamRequest
-  def initialize(operations, token: APIConfig.token)
-    request(
-      method: :patch,
-      url: "#{APIConfig.api_request_url}/teams/mine",
-      headers: {
-        'Authorization' => "Bearer #{token}"
-      },
-      payload: operations.map(&:payload).to_json
-    )
-  end
+module Typeform
+  class UpdateTeamRequest < TeamRequest
+    def initialize(operations, token: APIConfig.token)
+      request(
+        method: :patch,
+        url: "#{APIConfig.api_request_url}/teams/mine",
+        headers: {
+          'Authorization' => "Bearer #{token}"
+        },
+        payload: operations.map(&:payload).to_json
+      )
+    end
 
-  def success?
-    @response.code == 204
+    def success?
+      @response.code == 204
+    end
   end
 end

--- a/lib/create_api_gem/themes/background.rb
+++ b/lib/create_api_gem/themes/background.rb
@@ -15,49 +15,51 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class Background
-  attr_accessor :href, :brightness, :layout
+module Typeform
+  class Background
+    attr_accessor :href, :brightness, :layout
 
-  def initialize(href: nil, brightness: nil, layout: nil)
-    @href = href
-    @brightness = brightness
-    @layout = layout
-  end
+    def initialize(href: nil, brightness: nil, layout: nil)
+      @href = href
+      @brightness = brightness
+      @layout = layout
+    end
 
-  def payload
-    payload = {
-      href: href
-    }
-    payload[:brightness] = brightness unless brightness.nil?
-    payload[:layout] = layout unless layout.nil?
-    payload
-  end
+    def payload
+      payload = {
+        href: href
+      }
+      payload[:brightness] = brightness unless brightness.nil?
+      payload[:layout] = layout unless layout.nil?
+      payload
+    end
 
-  def self.from_response(payload)
-    new(
-      href: payload[:href],
-      layout: payload[:layout],
-      brightness: payload[:brightness]
-    )
-  end
+    def self.from_response(payload)
+      new(
+        href: payload[:href],
+        layout: payload[:layout],
+        brightness: payload[:brightness]
+      )
+    end
 
-  def self.default
-    Background.new(
-      brightness: 0,
-      layout: 'repeat'
-    )
-  end
+    def self.default
+      Background.new(
+        brightness: 0,
+        layout: 'repeat'
+      )
+    end
 
-  def self.full_example
-    Background.new(
-      href: "#{APIConfig.image_api_request_url}/images/default",
-      brightness: 0.5,
-      layout: 'no-repeat'
-    )
-  end
+    def self.full_example
+      Background.new(
+        href: "#{APIConfig.image_api_request_url}/images/default",
+        brightness: 0.5,
+        layout: 'no-repeat'
+      )
+    end
 
-  def same?(actual)
-    (layout.nil? ? Background.default.layout : layout) == actual.layout &&
-      (brightness.nil? ? Background.default.brightness : brightness) == actual.brightness
+    def same?(actual)
+      (layout.nil? ? Background.default.layout : layout) == actual.layout &&
+        (brightness.nil? ? Background.default.brightness : brightness) == actual.brightness
+    end
   end
 end

--- a/lib/create_api_gem/themes/requests/create_theme_request.rb
+++ b/lib/create_api_gem/themes/requests/create_theme_request.rb
@@ -17,19 +17,21 @@
 
 require_relative 'theme_request'
 
-class CreateThemeRequest < ThemeRequest
-  def initialize(theme, token: APIConfig.token)
-    request(
-      method: :post,
-      url: "#{APIConfig.api_request_url}/themes",
-      headers: {
-        'Authorization' => "Bearer #{token}"
-      },
-      payload: theme.payload
-    )
-  end
+module Typeform
+  class CreateThemeRequest < ThemeRequest
+    def initialize(theme, token: APIConfig.token)
+      request(
+        method: :post,
+        url: "#{APIConfig.api_request_url}/themes",
+        headers: {
+          'Authorization' => "Bearer #{token}"
+        },
+        payload: theme.payload
+      )
+    end
 
-  def success?
-    @response.code == 201 && json?
+    def success?
+      @response.code == 201 && json?
+    end
   end
 end

--- a/lib/create_api_gem/themes/requests/delete_theme_request.rb
+++ b/lib/create_api_gem/themes/requests/delete_theme_request.rb
@@ -17,18 +17,20 @@
 
 require_relative 'theme_request'
 
-class DeleteThemeRequest < ThemeRequest
-  def initialize(theme, token: APIConfig.token)
-    request(
-      method: :delete,
-      url: "#{APIConfig.api_request_url}/themes/#{theme.id}",
-      headers: {
-        'Authorization' => "Bearer #{token}"
-      }
-    )
-  end
+module Typeform
+  class DeleteThemeRequest < ThemeRequest
+    def initialize(theme, token: APIConfig.token)
+      request(
+        method: :delete,
+        url: "#{APIConfig.api_request_url}/themes/#{theme.id}",
+        headers: {
+          'Authorization' => "Bearer #{token}"
+        }
+      )
+    end
 
-  def success?
-    @response.code == 204
+    def success?
+      @response.code == 204
+    end
   end
 end

--- a/lib/create_api_gem/themes/requests/retrieve_all_themes_request.rb
+++ b/lib/create_api_gem/themes/requests/retrieve_all_themes_request.rb
@@ -18,40 +18,42 @@
 require_relative 'theme_request'
 require 'rack'
 
-class RetrieveAllThemesRequest < APIRequest
-  def initialize(token: APIConfig.token, page: nil, page_size: nil, visibility: nil)
-    filters = {}
-    filters[:page] = page unless page.nil?
-    filters[:page_size] = page_size unless page_size.nil?
-    filters[:visibility] = visibility unless visibility.nil?
-    parameters = Rack::Utils.build_query(filters)
-    request(
-      method: :get,
-      url: "#{APIConfig.api_request_url}/themes?" + parameters,
-      headers: {
-        'Authorization' => "Bearer #{token}"
-      },
-      verify_ssl: OpenSSL::SSL::VERIFY_NONE
-    )
-  end
+module Typeform
+  class RetrieveAllThemesRequest < APIRequest
+    def initialize(token: APIConfig.token, page: nil, page_size: nil, visibility: nil)
+      filters = {}
+      filters[:page] = page unless page.nil?
+      filters[:page_size] = page_size unless page_size.nil?
+      filters[:visibility] = visibility unless visibility.nil?
+      parameters = Rack::Utils.build_query(filters)
+      request(
+        method: :get,
+        url: "#{APIConfig.api_request_url}/themes?" + parameters,
+        headers: {
+          'Authorization' => "Bearer #{token}"
+        },
+        verify_ssl: OpenSSL::SSL::VERIFY_NONE
+      )
+    end
 
-  def bad_request?
-    @response.code == 400 && json?
-  end
+    def bad_request?
+      @response.code == 400 && json?
+    end
 
-  def success?
-    @response.code == 200 && json?
-  end
+    def success?
+      @response.code == 200 && json?
+    end
 
-  def themes
-    json.fetch(:items)
-  end
+    def themes
+      json.fetch(:items)
+    end
 
-  def total_items
-    json.fetch(:total_items)
-  end
+    def total_items
+      json.fetch(:total_items)
+    end
 
-  def page_count
-    json.fetch(:page_count)
+    def page_count
+      json.fetch(:page_count)
+    end
   end
 end

--- a/lib/create_api_gem/themes/requests/retrieve_theme_request.rb
+++ b/lib/create_api_gem/themes/requests/retrieve_theme_request.rb
@@ -17,18 +17,20 @@
 
 require_relative 'theme_request'
 
-class RetrieveThemeRequest < ThemeRequest
-  def initialize(theme, token: APIConfig.token)
-    headers = {}
-    headers = { 'Authorization' => "Bearer #{token}" } unless token.nil?
-    request(
-      method: :get,
-      url: "#{APIConfig.api_request_url}/themes/#{theme.id}",
-      headers: headers
-    )
-  end
+module Typeform
+  class RetrieveThemeRequest < ThemeRequest
+    def initialize(theme, token: APIConfig.token)
+      headers = {}
+      headers = { 'Authorization' => "Bearer #{token}" } unless token.nil?
+      request(
+        method: :get,
+        url: "#{APIConfig.api_request_url}/themes/#{theme.id}",
+        headers: headers
+      )
+    end
 
-  def success?
-    @response.code == 200 && json?
+    def success?
+      @response.code == 200 && json?
+    end
   end
 end

--- a/lib/create_api_gem/themes/requests/theme_request.rb
+++ b/lib/create_api_gem/themes/requests/theme_request.rb
@@ -17,28 +17,30 @@
 
 require_relative '../../api_request'
 
-class ThemeRequest < APIRequest
-  def location_header
-    headers.fetch(:location)
-  end
+module Typeform
+  class ThemeRequest < APIRequest
+    def location_header
+      headers.fetch(:location)
+    end
 
-  def theme
-    Theme.from_response(json)
-  end
+    def theme
+      Theme.from_response(json)
+    end
 
-  def invalid_theme?
-    @response.code == 400
-  end
+    def invalid_theme?
+      @response.code == 400
+    end
 
-  def not_found_theme?
-    @response.code == 404
-  end
+    def not_found_theme?
+      @response.code == 404
+    end
 
-  def forbidden?
-    @response.code == 403
-  end
+    def forbidden?
+      @response.code == 403
+    end
 
-  def theme_id
-    headers.fetch(:location).split('/themes/')[1]
+    def theme_id
+      headers.fetch(:location).split('/themes/')[1]
+    end
   end
 end

--- a/lib/create_api_gem/themes/requests/update_theme_request.rb
+++ b/lib/create_api_gem/themes/requests/update_theme_request.rb
@@ -17,19 +17,21 @@
 
 require_relative 'theme_request'
 
-class UpdateThemeRequest < ThemeRequest
-  def initialize(theme, token: APIConfig.token)
-    request(
-      method: :put,
-      url: "#{APIConfig.api_request_url}/themes/#{theme.id}",
-      headers: {
-        'Authorization' => "Bearer #{token}"
-      },
-      payload: theme.payload
-    )
-  end
+module Typeform
+  class UpdateThemeRequest < ThemeRequest
+    def initialize(theme, token: APIConfig.token)
+      request(
+        method: :put,
+        url: "#{APIConfig.api_request_url}/themes/#{theme.id}",
+        headers: {
+          'Authorization' => "Bearer #{token}"
+        },
+        payload: theme.payload
+      )
+    end
 
-  def success?
-    @response.code == 200 && json?
+    def success?
+      @response.code == 200 && json?
+    end
   end
 end

--- a/lib/create_api_gem/themes/theme.rb
+++ b/lib/create_api_gem/themes/theme.rb
@@ -15,88 +15,90 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class Theme
-  attr_accessor :id, :name, :font, :colors, :visibility, :has_transparent_button, :background
+module Typeform
+  class Theme
+    attr_accessor :id, :name, :font, :colors, :visibility, :has_transparent_button, :background
 
-  def initialize(id: nil, name: nil, font: nil, colors: nil, visibility: nil, has_transparent_button: nil, background: nil)
-    @id = id
-    @name = name || DataGenerator.title
-    @font = font || 'Arial'
-    @colors = colors || Theme.colors
-    @visibility = visibility || 'private'
-    @has_transparent_button = has_transparent_button
-    @background = background
-  end
+    def initialize(id: nil, name: nil, font: nil, colors: nil, visibility: nil, has_transparent_button: nil, background: nil)
+      @id = id
+      @name = name || DataGenerator.title
+      @font = font || 'Arial'
+      @colors = colors || Theme.colors
+      @visibility = visibility || 'private'
+      @has_transparent_button = has_transparent_button
+      @background = background
+    end
 
-  def self.default
-    Theme.new(
-      id: 'gJ3gfQ',
-      name: 'Default',
-      colors: [
-        question: '#3D3D3D',
-        answer: '#4FB0AE',
-        button: '#4FB0AE',
-        background: '#FFFFFF'
-      ],
-      font: 'Karla',
-      has_transparent_button: false,
-      visibility: 'private'
-    )
-  end
+    def self.default
+      Theme.new(
+        id: 'gJ3gfQ',
+        name: 'Default',
+        colors: [
+          question: '#3D3D3D',
+          answer: '#4FB0AE',
+          button: '#4FB0AE',
+          background: '#FFFFFF'
+        ],
+        font: 'Karla',
+        has_transparent_button: false,
+        visibility: 'private'
+      )
+    end
 
-  def self.full_example
-    Theme.new(
-      name: DataGenerator.title,
-      colors: colors,
-      font: 'Nixie One',
-      has_transparent_button: true,
-      visibility: 'private',
-      background: Background.full_example
-    )
-  end
+    def self.full_example
+      Theme.new(
+        name: DataGenerator.title,
+        colors: colors,
+        font: 'Nixie One',
+        has_transparent_button: true,
+        visibility: 'private',
+        background: Background.full_example
+      )
+    end
 
-  def self.colors
-    {
-      question: DataGenerator.color_code,
-      answer: DataGenerator.color_code,
-      button: DataGenerator.color_code,
-      background: DataGenerator.color_code
-    }
-  end
+    def self.colors
+      {
+        question: DataGenerator.color_code,
+        answer: DataGenerator.color_code,
+        button: DataGenerator.color_code,
+        background: DataGenerator.color_code
+      }
+    end
 
-  def payload
-    payload = {
-      name: name,
-      font: font,
-      colors: colors
-    }
-    payload[:has_transparent_button] = has_transparent_button unless has_transparent_button.nil?
-    payload[:visibility] = visibility unless visibility.nil?
-    payload[:background] = background.payload unless background.nil?
-    payload.to_json
-  end
+    def payload
+      payload = {
+        name: name,
+        font: font,
+        colors: colors
+      }
+      payload[:has_transparent_button] = has_transparent_button unless has_transparent_button.nil?
+      payload[:visibility] = visibility unless visibility.nil?
+      payload[:background] = background.payload unless background.nil?
+      payload.to_json
+    end
 
-  def self.from_response(payload)
-    background = payload[:background].nil? ? nil : Background.from_response(payload[:background])
-    new(
-      id: payload[:id],
-      name: payload[:name],
-      font: payload[:font],
-      colors: payload[:colors],
-      visibility: payload[:visibility],
-      has_transparent_button: payload[:has_transparent_button],
-      background: background
-    )
-  end
+    def self.from_response(payload)
+      background = payload[:background].nil? ? nil : Background.from_response(payload[:background])
+      new(
+        id: payload[:id],
+        name: payload[:name],
+        font: payload[:font],
+        colors: payload[:colors],
+        visibility: payload[:visibility],
+        has_transparent_button: payload[:has_transparent_button],
+        background: background
+      )
+    end
 
-  def same?(actual)
-    (id.nil? || id == actual.id) &&
-      name == actual.name &&
-      colors == actual.colors &&
-      colors.keys == %i[question answer button background] &&
-      font == actual.font &&
-      (visibility.nil? ? Theme.default.visibility : visibility) == actual.visibility &&
-      (has_transparent_button.nil? ? Theme.default.has_transparent_button : has_transparent_button) == actual.has_transparent_button &&
-      (background.nil? || background.same?(actual.background))
+    def same?(actual)
+      (id.nil? || id == actual.id) &&
+        name == actual.name &&
+        colors == actual.colors &&
+        colors.keys == %i[question answer button background] &&
+        font == actual.font &&
+        (visibility.nil? ? Theme.default.visibility : visibility) == actual.visibility &&
+        (has_transparent_button.nil? ? Theme.default.has_transparent_button : has_transparent_button) == actual.has_transparent_button &&
+        (background.nil? || background.same?(actual.background))
+    end
   end
 end

--- a/lib/create_api_gem/version.rb
+++ b/lib/create_api_gem/version.rb
@@ -16,5 +16,5 @@
 # under the License.
 
 module CreateApiGem
-  VERSION = '0.0.1'.freeze
+  VERSION = '1.0.0'.freeze
 end

--- a/lib/create_api_gem/workspaces/requests/create_workspace_request.rb
+++ b/lib/create_api_gem/workspaces/requests/create_workspace_request.rb
@@ -17,24 +17,26 @@
 
 require_relative 'workspace_request'
 
-class CreateWorkspaceRequest < WorkspaceRequest
-  def initialize(workspace, token: APIConfig.token)
-    request(
-      method: :post,
-      url: APIConfig.workspaces_api_request_url,
-      headers: {
-        'Authorization' => "Bearer #{token}",
-        'Content-Type' => 'application/json'
-      },
-      payload: workspace.payload
-    )
-  end
+module Typeform
+  class CreateWorkspaceRequest < WorkspaceRequest
+    def initialize(workspace, token: APIConfig.token)
+      request(
+        method: :post,
+        url: APIConfig.workspaces_api_request_url,
+        headers: {
+          'Authorization' => "Bearer #{token}",
+          'Content-Type' => 'application/json'
+        },
+        payload: workspace.payload
+      )
+    end
 
-  def success?
-    @response.code == 201 && json? && json.key?(:forms) && json.key?(:self)
-  end
+    def success?
+      @response.code == 201 && json? && json.key?(:forms) && json.key?(:self)
+    end
 
-  def location_header
-    headers.fetch(:location)
+    def location_header
+      headers.fetch(:location)
+    end
   end
 end

--- a/lib/create_api_gem/workspaces/requests/delete_workspace_request.rb
+++ b/lib/create_api_gem/workspaces/requests/delete_workspace_request.rb
@@ -17,23 +17,25 @@
 
 require_relative 'workspace_request'
 
-class DeleteWorkspaceRequest < WorkspaceRequest
-  def initialize(workspace, token: APIConfig.token)
-    request(
-      method: :delete,
-      url: "#{APIConfig.workspaces_api_request_url}/#{workspace.id}",
-      headers: {
-        'Authorization' => "Bearer #{token}",
-        'Content-Type' => 'application/json'
-      }
-    )
-  end
+module Typeform
+  class DeleteWorkspaceRequest < WorkspaceRequest
+    def initialize(workspace, token: APIConfig.token)
+      request(
+        method: :delete,
+        url: "#{APIConfig.workspaces_api_request_url}/#{workspace.id}",
+        headers: {
+          'Authorization' => "Bearer #{token}",
+          'Content-Type' => 'application/json'
+        }
+      )
+    end
 
-  def success?
-    @response.code == 204
-  end
+    def success?
+      @response.code == 204
+    end
 
-  def invalid_operation?
-    @response.code == 400
+    def invalid_operation?
+      @response.code == 400
+    end
   end
 end

--- a/lib/create_api_gem/workspaces/requests/retrieve_all_workspaces_request.rb
+++ b/lib/create_api_gem/workspaces/requests/retrieve_all_workspaces_request.rb
@@ -18,33 +18,35 @@
 require_relative 'workspace_request'
 require 'open-uri'
 
-class RetrieveAllWorkspacesRequest < WorkspaceRequest
-  def initialize(token: APIConfig.token, workspaces_per_page: 10, page: nil, search: nil)
-    url = "#{APIConfig.workspaces_api_request_url}?"
-    url << "page_size=#{workspaces_per_page}&" unless workspaces_per_page.nil?
-    url << "page=#{page}&" unless page.nil?
-    url << "search=#{URI.encode_www_form_component(search)}&" unless search.nil?
-    request(
-      method: :get,
-      url: url,
-      headers: {
-        'Authorization' => "Bearer #{token}",
-        'Content-Type' => 'application/json'
-      }
-    )
-  end
-
-  def success?
-    @response.code == 200 && json?
-  end
-
-  def workspaces
-    json.fetch(:items).map do |workspace_json|
-      Workspace.from_response(workspace_json)
+module Typeform
+  class RetrieveAllWorkspacesRequest < WorkspaceRequest
+    def initialize(token: APIConfig.token, workspaces_per_page: 10, page: nil, search: nil)
+      url = "#{APIConfig.workspaces_api_request_url}?"
+      url << "page_size=#{workspaces_per_page}&" unless workspaces_per_page.nil?
+      url << "page=#{page}&" unless page.nil?
+      url << "search=#{URI.encode_www_form_component(search)}&" unless search.nil?
+      request(
+        method: :get,
+        url: url,
+        headers: {
+          'Authorization' => "Bearer #{token}",
+          'Content-Type' => 'application/json'
+        }
+      )
     end
-  end
 
-  def default_workspace
-    workspaces.find(&:default)
+    def success?
+      @response.code == 200 && json?
+    end
+
+    def workspaces
+      json.fetch(:items).map do |workspace_json|
+        Workspace.from_response(workspace_json)
+      end
+    end
+
+    def default_workspace
+      workspaces.find(&:default)
+    end
   end
 end

--- a/lib/create_api_gem/workspaces/requests/retrieve_default_workspace_request.rb
+++ b/lib/create_api_gem/workspaces/requests/retrieve_default_workspace_request.rb
@@ -17,19 +17,21 @@
 
 require_relative 'workspace_request'
 
-class RetrieveDefaultWorkspaceRequest < WorkspaceRequest
-  def initialize(token: APIConfig.token)
-    request(
-      method: :get,
-      url: "#{APIConfig.workspaces_api_request_url}/default",
-      headers: {
-        'Authorization' => "Bearer #{token}",
-        'Content-Type' => 'application/json'
-      }
-    )
-  end
+module Typeform
+  class RetrieveDefaultWorkspaceRequest < WorkspaceRequest
+    def initialize(token: APIConfig.token)
+      request(
+        method: :get,
+        url: "#{APIConfig.workspaces_api_request_url}/default",
+        headers: {
+          'Authorization' => "Bearer #{token}",
+          'Content-Type' => 'application/json'
+        }
+      )
+    end
 
-  def success?
-    @response.code == 200 && json? && json.key?(:forms) && json.key?(:self)
+    def success?
+      @response.code == 200 && json? && json.key?(:forms) && json.key?(:self)
+    end
   end
 end

--- a/lib/create_api_gem/workspaces/requests/retrieve_workspace_request.rb
+++ b/lib/create_api_gem/workspaces/requests/retrieve_workspace_request.rb
@@ -17,19 +17,21 @@
 
 require_relative 'workspace_request'
 
-class RetrieveWorkspaceRequest < WorkspaceRequest
-  def initialize(workspace, token: APIConfig.token)
-    request(
-      method: :get,
-      url: "#{APIConfig.workspaces_api_request_url}/#{workspace.id}",
-      headers: {
-        'Authorization' => "Bearer #{token}",
-        'Content-Type' => 'application/json'
-      }
-    )
-  end
+module Typeform
+  class RetrieveWorkspaceRequest < WorkspaceRequest
+    def initialize(workspace, token: APIConfig.token)
+      request(
+        method: :get,
+        url: "#{APIConfig.workspaces_api_request_url}/#{workspace.id}",
+        headers: {
+          'Authorization' => "Bearer #{token}",
+          'Content-Type' => 'application/json'
+        }
+      )
+    end
 
-  def success?
-    @response.code == 200 && json? && json.key?(:forms) && json.key?(:self)
+    def success?
+      @response.code == 200 && json? && json.key?(:forms) && json.key?(:self)
+    end
   end
 end

--- a/lib/create_api_gem/workspaces/requests/update_workspace_request.rb
+++ b/lib/create_api_gem/workspaces/requests/update_workspace_request.rb
@@ -17,20 +17,22 @@
 
 require_relative 'workspace_request'
 
-class UpdateWorkspaceRequest < WorkspaceRequest
-  def initialize(workspace, operations, token: APIConfig.token)
-    request(
-      method: :patch,
-      url: "#{APIConfig.workspaces_api_request_url}/#{workspace.id}",
-      headers: {
-        'Authorization' => "Bearer #{token}",
-        'Content-Type' => 'application/json'
-      },
-      payload: operations.map(&:payload).to_json
-    )
-  end
+module Typeform
+  class UpdateWorkspaceRequest < WorkspaceRequest
+    def initialize(workspace, operations, token: APIConfig.token)
+      request(
+        method: :patch,
+        url: "#{APIConfig.workspaces_api_request_url}/#{workspace.id}",
+        headers: {
+          'Authorization' => "Bearer #{token}",
+          'Content-Type' => 'application/json'
+        },
+        payload: operations.map(&:payload).to_json
+      )
+    end
 
-  def success?
-    @response.code == 204
+    def success?
+      @response.code == 204
+    end
   end
 end

--- a/lib/create_api_gem/workspaces/requests/workspace_request.rb
+++ b/lib/create_api_gem/workspaces/requests/workspace_request.rb
@@ -17,24 +17,26 @@
 
 require_relative '../../api_request'
 
-class WorkspaceRequest < APIRequest
-  def workspace
-    Workspace.from_response(json)
-  end
+module Typeform
+  class WorkspaceRequest < APIRequest
+    def workspace
+      Workspace.from_response(json)
+    end
 
-  def unauthorized?
-    @response.code == 401
-  end
+    def unauthorized?
+      @response.code == 401
+    end
 
-  def not_found?
-    @response.code == 404
-  end
+    def not_found?
+      @response.code == 404
+    end
 
-  def forbidden?
-    @response.code == 403
-  end
+    def forbidden?
+      @response.code == 403
+    end
 
-  def bad_request?
-    @response.code == 400
+    def bad_request?
+      @response.code == 400
+    end
   end
 end

--- a/lib/create_api_gem/workspaces/workspace.rb
+++ b/lib/create_api_gem/workspaces/workspace.rb
@@ -15,41 +15,43 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class Workspace
-  attr_accessor :name, :id, :default, :shared, :members
+module Typeform
+  class Workspace
+    attr_accessor :name, :id, :default, :shared, :members
 
-  def initialize(name: nil, id: nil, default: nil, shared: nil, members: nil)
-    @name = name || DataGenerator.title
-    @id = id
-    @default = default
-    @shared = shared
-    @members = members
-  end
+    def initialize(name: nil, id: nil, default: nil, shared: nil, members: nil)
+      @name = name || DataGenerator.title
+      @id = id
+      @default = default
+      @shared = shared
+      @members = members
+    end
 
-  def payload
-    {
-      name: name
-    }.to_json
-  end
+    def payload
+      {
+        name: name
+      }.to_json
+    end
 
-  def same?(actual)
-    name == actual.name &&
-      id.nil? || id == actual.id &&
-        (default.nil? ? Workspace.default.default : default) == actual.default &&
-        (shared.nil? ? Workspace.default.shared : shared) == actual.shared
-  end
+    def same?(actual)
+      name == actual.name &&
+        id.nil? || id == actual.id &&
+          (default.nil? ? Workspace.default.default : default) == actual.default &&
+          (shared.nil? ? Workspace.default.shared : shared) == actual.shared
+    end
 
-  def self.default
-    Workspace.new(default: false, shared: false)
-  end
+    def self.default
+      Workspace.new(default: false, shared: false)
+    end
 
-  def self.from_response(payload)
-    new(
-      name: payload[:name],
-      id: payload[:id],
-      default: payload[:default],
-      shared: payload[:shared],
-      members: payload[:members]
-    )
+    def self.from_response(payload)
+      new(
+        name: payload[:name],
+        id: payload[:id],
+        default: payload[:default],
+        shared: payload[:shared],
+        members: payload[:members]
+      )
+    end
   end
 end

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -24,12 +24,14 @@ SimpleCov.command_name 'Gem Unit Tests'
 require 'minitest/autorun'
 require 'create_api_gem'
 
-class TestBase < Minitest::Test
-  def token
-    ENV['TYPEFORM_API_TOKEN']
-  end
+module Typeform
+  class TestBase < Minitest::Test
+    def token
+      ENV['TYPEFORM_API_TOKEN']
+    end
 
-  def email
-    'maria_jose@typeform.com'
+    def email
+      'maria_jose@typeform.com'
+    end
   end
 end

--- a/test/test_forms.rb
+++ b/test/test_forms.rb
@@ -15,90 +15,92 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class FormsTest < TestBase
-  def test_all_requests
-    form = Form.full_example
+module Typeform
+  class FormsTest < TestBase
+    def test_all_requests
+      form = Form.full_example
 
-    create_form = CreateFormRequest.new(form)
-    assert_equal create_form.success?, true
-    assert_equal form.same?(create_form.form), true
-    form = create_form.form
+      create_form = CreateFormRequest.new(form)
+      assert_equal create_form.success?, true
+      assert_equal form.same?(create_form.form), true
+      form = create_form.form
 
-    retrieve_form = RetrieveFormRequest.new(form)
-    assert_equal retrieve_form.success?, true
-    assert_equal form.same?(retrieve_form.form), true
-    form = retrieve_form.form
+      retrieve_form = RetrieveFormRequest.new(form)
+      assert_equal retrieve_form.success?, true
+      assert_equal form.same?(retrieve_form.form), true
+      form = retrieve_form.form
 
-    head_form = HeadFormRequest.new(form)
-    assert_equal head_form.success?, true
+      head_form = HeadFormRequest.new(form)
+      assert_equal head_form.success?, true
 
-    retrieve_all_forms = RetrieveAllFormsRequest.new
-    assert_equal retrieve_all_forms.success?, true
+      retrieve_all_forms = RetrieveAllFormsRequest.new
+      assert_equal retrieve_all_forms.success?, true
 
-    update_form = UpdateFormRequest.new(form)
-    assert_equal update_form.success?, true
-    assert_equal form.same?(update_form.form), true
-    form = update_form.form
+      update_form = UpdateFormRequest.new(form)
+      assert_equal update_form.success?, true
+      assert_equal form.same?(update_form.form), true
+      form = update_form.form
 
-    patch_operations = [PatchOperation.new(op: 'replace', path: '/title', value: 'new title')]
-    update_patch_form = UpdateFormPatchRequest.new(form, patch_operations)
-    assert_equal update_patch_form.success?, true
+      patch_operations = [PatchOperation.new(op: 'replace', path: '/title', value: 'new title')]
+      update_patch_form = UpdateFormPatchRequest.new(form, patch_operations)
+      assert_equal update_patch_form.success?, true
 
-    delete_form = DeleteFormRequest.new(form)
-    assert_equal delete_form.success?, true
-  end
+      delete_form = DeleteFormRequest.new(form)
+      assert_equal delete_form.success?, true
+    end
 
-  def test_form_same_method
-    form = Form.full_example
-    same_form = form.dup
-    assert_equal form.same?(same_form), true
+    def test_form_same_method
+      form = Form.full_example
+      same_form = form.dup
+      assert_equal form.same?(same_form), true
 
-    different_form = form.dup
-    different_form.title = DataGenerator.title
-    assert_equal form.same?(different_form), false
-  end
+      different_form = form.dup
+      different_form.title = DataGenerator.title
+      assert_equal form.same?(different_form), false
+    end
 
-  def test_block_same_method
-    block = ShortTextBlock.full_example
-    same_block = block.dup
-    assert_equal block.same?(same_block), true
+    def test_block_same_method
+      block = ShortTextBlock.full_example
+      same_block = block.dup
+      assert_equal block.same?(same_block), true
 
-    different_block = block.dup
-    different_block.ref = DataGenerator.field_ref
-    assert_equal block.same?(different_block), false
-  end
+      different_block = block.dup
+      different_block.ref = DataGenerator.field_ref
+      assert_equal block.same?(different_block), false
+    end
 
-  def test_logic_same_method
-    logic_jump = LogicJump.create_always_jump(Form.full_example)
-    same_logic_jump = logic_jump.dup
-    assert_equal logic_jump.same?(same_logic_jump), true
+    def test_logic_same_method
+      logic_jump = LogicJump.create_always_jump(Form.full_example)
+      same_logic_jump = logic_jump.dup
+      assert_equal logic_jump.same?(same_logic_jump), true
 
-    different_logic_jump = logic_jump.dup
-    different_logic_jump.to_ref = DataGenerator.field_ref
-    assert_equal logic_jump.same?(different_logic_jump), false
-  end
+      different_logic_jump = logic_jump.dup
+      different_logic_jump.to_ref = DataGenerator.field_ref
+      assert_equal logic_jump.same?(different_logic_jump), false
+    end
 
-  def test_settings_same_method
-    settings = Settings.full_example(DataGenerator.field_ref)
-    same_settings = settings.dup
-    assert_equal settings.same?(same_settings), true
+    def test_settings_same_method
+      settings = Settings.full_example(DataGenerator.field_ref)
+      same_settings = settings.dup
+      assert_equal settings.same?(same_settings), true
 
-    different_settings = settings.dup
-    different_settings.is_public = false
-    assert_equal settings.same?(different_settings), false
-  end
+      different_settings = settings.dup
+      different_settings.is_public = false
+      assert_equal settings.same?(different_settings), false
+    end
 
-  def test_messages
-    form = CreateFormRequest.execute(Form.new).form
+    def test_messages
+      form = CreateFormRequest.execute(Form.new).form
 
-    retrieve_messages = RetrieveMessagesRequest.new(form)
-    assert_equal retrieve_messages.success?, true
+      retrieve_messages = RetrieveMessagesRequest.new(form)
+      assert_equal retrieve_messages.success?, true
 
-    messages = Messages.new('label.button.ok' => 'New Ok')
-    update_messages = UpdateMessagesRequest.new(form, messages)
-    assert_equal update_messages.success?, true
-    assert_equal messages.same?(RetrieveMessagesRequest.execute(form).messages), true
+      messages = Messages.new('label.button.ok' => 'New Ok')
+      update_messages = UpdateMessagesRequest.new(form, messages)
+      assert_equal update_messages.success?, true
+      assert_equal messages.same?(RetrieveMessagesRequest.execute(form).messages), true
 
-    DeleteFormRequest.execute(form)
+      DeleteFormRequest.execute(form)
+    end
   end
 end

--- a/test/test_images.rb
+++ b/test/test_images.rb
@@ -15,38 +15,40 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class ImagesTest < TestBase
-  def test_all_requests
-    image = Image.full_example
+module Typeform
+  class ImagesTest < TestBase
+    def test_all_requests
+      image = Image.full_example
 
-    create_image = CreateImageRequest.new(image)
-    assert_equal create_image.success?, true
-    image = create_image.image
+      create_image = CreateImageRequest.new(image)
+      assert_equal create_image.success?, true
+      image = create_image.image
 
-    retrieve_image = RetrieveImageRequest.new(image, accept: 'json')
-    assert_equal retrieve_image.success?, true
-    assert_equal image.id == retrieve_image.image.id, true
-    assert_equal image.file_name == retrieve_image.image.file_name, true
-    assert_equal image.media_type == retrieve_image.image.media_type, true
-    image = retrieve_image.image
+      retrieve_image = RetrieveImageRequest.new(image, accept: 'json')
+      assert_equal retrieve_image.success?, true
+      assert_equal image.id == retrieve_image.image.id, true
+      assert_equal image.file_name == retrieve_image.image.file_name, true
+      assert_equal image.media_type == retrieve_image.image.media_type, true
+      image = retrieve_image.image
 
-    retrieve_frame = RetrieveFrameRequest.new(image, 'first')
-    assert_equal retrieve_frame.success?, true
+      retrieve_frame = RetrieveFrameRequest.new(image, 'first')
+      assert_equal retrieve_frame.success?, true
 
-    retrieve_all_images = RetrieveAllImagesRequest.new
-    assert_equal retrieve_all_images.success?, true
+      retrieve_all_images = RetrieveAllImagesRequest.new
+      assert_equal retrieve_all_images.success?, true
 
-    delete_image = DeleteImageRequest.new(image)
-    assert_equal delete_image.success?, true
-  end
+      delete_image = DeleteImageRequest.new(image)
+      assert_equal delete_image.success?, true
+    end
 
-  def test_same_method
-    image = Image.full_example
-    same_image = image.dup
-    assert_equal image.same?(same_image), true
+    def test_same_method
+      image = Image.full_example
+      same_image = image.dup
+      assert_equal image.same?(same_image), true
 
-    different_image = image.dup
-    different_image.file_name = 'different_file_name'
-    assert_equal image.same?(different_image), false
+      different_image = image.dup
+      different_image.file_name = 'different_file_name'
+      assert_equal image.same?(different_image), false
+    end
   end
 end

--- a/test/test_teams.rb
+++ b/test/test_teams.rb
@@ -18,15 +18,17 @@
 require 'minitest/autorun'
 require 'create_api_gem'
 
-class TeamsTest < TestBase
-  def test_all_requests
-    retrieve_team = RetrieveTeamRequest.new
-    assert retrieve_team.success?, true
+module Typeform
+  class TeamsTest < TestBase
+    def test_all_requests
+      retrieve_team = RetrieveTeamRequest.new
+      assert retrieve_team.success?, true
 
-    default_workspace = RetrieveAllWorkspacesRequest.execute.default_workspace
-    UpdateWorkspaceRequest.execute(default_workspace, [PatchOperation.new(op: 'add', path: '/members', value: { email: email })])
+      default_workspace = RetrieveAllWorkspacesRequest.execute.default_workspace
+      UpdateWorkspaceRequest.execute(default_workspace, [PatchOperation.new(op: 'add', path: '/members', value: { email: email })])
 
-    update_team = UpdateTeamRequest.new([PatchOperation.new(op: 'remove', path: '/members', value: { email: email })])
-    assert update_team.success?, true
+      update_team = UpdateTeamRequest.new([PatchOperation.new(op: 'remove', path: '/members', value: { email: email })])
+      assert update_team.success?, true
+    end
   end
 end

--- a/test/test_themes.rb
+++ b/test/test_themes.rb
@@ -15,40 +15,42 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class ThemesTest < TestBase
-  def test_all_requests
-    theme = Theme.full_example
+module Typeform
+  class ThemesTest < TestBase
+    def test_all_requests
+      theme = Theme.full_example
 
-    create_theme = CreateThemeRequest.new(theme)
-    assert_equal create_theme.success?, true
-    assert_equal theme.same?(create_theme.theme), true
-    theme = create_theme.theme
+      create_theme = CreateThemeRequest.new(theme)
+      assert_equal create_theme.success?, true
+      assert_equal theme.same?(create_theme.theme), true
+      theme = create_theme.theme
 
-    retrieve_theme = RetrieveThemeRequest.new(theme)
-    assert_equal retrieve_theme.success?, true
-    assert_equal theme.same?(retrieve_theme.theme), true
-    theme = retrieve_theme.theme
+      retrieve_theme = RetrieveThemeRequest.new(theme)
+      assert_equal retrieve_theme.success?, true
+      assert_equal theme.same?(retrieve_theme.theme), true
+      theme = retrieve_theme.theme
 
-    retrieve_all_themes = RetrieveAllThemesRequest.new(page: 1, page_size: 2, visibility: 'private')
-    assert_equal retrieve_all_themes.success?, true
+      retrieve_all_themes = RetrieveAllThemesRequest.new(page: 1, page_size: 2, visibility: 'private')
+      assert_equal retrieve_all_themes.success?, true
 
-    update_theme = UpdateThemeRequest.new(theme)
-    assert_equal update_theme.success?, true
-    assert_equal theme.same?(update_theme.theme), true
-    theme = update_theme.theme
+      update_theme = UpdateThemeRequest.new(theme)
+      assert_equal update_theme.success?, true
+      assert_equal theme.same?(update_theme.theme), true
+      theme = update_theme.theme
 
-    delete_theme = DeleteThemeRequest.new(theme)
-    assert_equal delete_theme.success?, true
-  end
+      delete_theme = DeleteThemeRequest.new(theme)
+      assert_equal delete_theme.success?, true
+    end
 
-  def test_same_method
-    theme = Theme.full_example
-    same_theme = theme.dup
+    def test_same_method
+      theme = Theme.full_example
+      same_theme = theme.dup
 
-    assert_equal theme.same?(same_theme), true
+      assert_equal theme.same?(same_theme), true
 
-    not_same_theme = theme.dup
-    not_same_theme.name = 'A different title'
-    assert_equal theme.same?(not_same_theme), false
+      not_same_theme = theme.dup
+      not_same_theme.name = 'A different title'
+      assert_equal theme.same?(not_same_theme), false
+    end
   end
 end

--- a/test/test_workspaces.rb
+++ b/test/test_workspaces.rb
@@ -15,48 +15,50 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class WorkspacesTest < TestBase
-  def test_all_requests
-    workspace = Workspace.new
+module Typeform
+  class WorkspacesTest < TestBase
+    def test_all_requests
+      workspace = Workspace.new
 
-    create_workspace = CreateWorkspaceRequest.new(workspace)
-    assert_equal create_workspace.success?, true
-    assert_equal workspace.same?(create_workspace.workspace), true
-    workspace = create_workspace.workspace
+      create_workspace = CreateWorkspaceRequest.new(workspace)
+      assert_equal create_workspace.success?, true
+      assert_equal workspace.same?(create_workspace.workspace), true
+      workspace = create_workspace.workspace
 
-    retrieve_workspace = RetrieveWorkspaceRequest.new(workspace)
-    assert_equal retrieve_workspace.success?, true
-    assert_equal workspace.same?(retrieve_workspace.workspace), true
-    workspace = retrieve_workspace.workspace
+      retrieve_workspace = RetrieveWorkspaceRequest.new(workspace)
+      assert_equal retrieve_workspace.success?, true
+      assert_equal workspace.same?(retrieve_workspace.workspace), true
+      workspace = retrieve_workspace.workspace
 
-    retrieve_all_workspaces = RetrieveAllWorkspacesRequest.new
-    assert_equal retrieve_all_workspaces.success?, true
+      retrieve_all_workspaces = RetrieveAllWorkspacesRequest.new
+      assert_equal retrieve_all_workspaces.success?, true
 
-    retrieve_default_workspace = RetrieveDefaultWorkspaceRequest.new
-    assert_equal retrieve_default_workspace.success?, true
+      retrieve_default_workspace = RetrieveDefaultWorkspaceRequest.new
+      assert_equal retrieve_default_workspace.success?, true
 
-    form = CreateFormRequest.execute(Form.new).form
-    operations = [
-      PatchOperation.new(op: 'replace', path: '/name', value: DataGenerator.title),
-      PatchOperation.new(op: 'add', path: '/members', value: { email: email })
-    ]
-    update_workspace = UpdateWorkspaceRequest.new(workspace, operations)
-    assert_equal update_workspace.success?, true
+      form = CreateFormRequest.execute(Form.new).form
+      operations = [
+        PatchOperation.new(op: 'replace', path: '/name', value: DataGenerator.title),
+        PatchOperation.new(op: 'add', path: '/members', value: { email: email })
+      ]
+      update_workspace = UpdateWorkspaceRequest.new(workspace, operations)
+      assert_equal update_workspace.success?, true
 
-    UpdateWorkspaceRequest.execute(workspace, [PatchOperation.new(op: 'remove', path: '/members', value: { email: email })])
-    DeleteFormRequest.execute(form)
+      UpdateWorkspaceRequest.execute(workspace, [PatchOperation.new(op: 'remove', path: '/members', value: { email: email })])
+      DeleteFormRequest.execute(form)
 
-    delete_workspace = DeleteWorkspaceRequest.new(workspace)
-    assert_equal delete_workspace.success?, true
-  end
+      delete_workspace = DeleteWorkspaceRequest.new(workspace)
+      assert_equal delete_workspace.success?, true
+    end
 
-  def test_same_method
-    workspace = Workspace.new
-    same_workspace = workspace.dup
-    assert_equal workspace.same?(same_workspace), true
+    def test_same_method
+      workspace = Workspace.new
+      same_workspace = workspace.dup
+      assert_equal workspace.same?(same_workspace), true
 
-    different_workspace = workspace.dup
-    different_workspace.name = DataGenerator.title
-    assert_equal workspace.same?(different_workspace), false
+      different_workspace = workspace.dup
+      different_workspace.name = DataGenerator.title
+      assert_equal workspace.same?(different_workspace), false
+    end
   end
 end


### PR DESCRIPTION
Enclose all gem classes in a `Typeform` namespace. Thus, when used in a project, classes do not collide with possible existing ones (likely with names such as `Form`, `APIFormat`, `APIRequest` and so on).

This has the effect of bumping the gem version to `1.0.0` because it is a breaking change for anyone using the gem (has to user `Typeform::Form` instead of `Form`, etc.)

Fixes #62 .