### PR TITLE
Fix for BREAKING API change: support for newly added id to API response to prevent exception

### DIFF
--- a/lib/create_api_gem/forms/blocks/thank_you_screen.rb
+++ b/lib/create_api_gem/forms/blocks/thank_you_screen.rb
@@ -18,7 +18,8 @@
 class ThankYouScreen < Block
   attr_accessor :title, :ref, :show_button, :button_text, :button_mode, :redirect_url, :share_icons, :attachment
 
-  def initialize(title: nil, ref: nil, show_button: nil, button_text: nil, button_mode: nil, redirect_url: nil, share_icons: nil, attachment: nil)
+  def initialize(title: nil, ref: nil, show_button: nil, button_text: nil, button_mode: nil, redirect_url: nil, share_icons: nil, attachment: nil, id: nil)
+    @id = id
     @title = title || DataGenerator.title
     @ref = ref
     @show_button = show_button


### PR DESCRIPTION

Seems like you added an id for the thank you screen in the payload when fetching a Form, without adding it to `initialize` it leads to an exception  `ArgumentError (unknown keyword: id):`

I don't know what you are supposed to do with the id so this PR is only making the gem as is work again but might need additional work from the Typeform team knowing what to do with this new id.