### PR TITLE
add new unexpected param from Typeform

### DIFF
--- a/lib/create_api_gem/forms/settings/settings.rb
+++ b/lib/create_api_gem/forms/settings/settings.rb
@@ -24,7 +24,7 @@ class Settings
   def initialize(redirect_after_submit_url: nil, show_typeform_branding: nil, progress_bar: nil,
                  show_progress_bar: nil, description: nil, allow_indexing: nil, image: nil, language: nil,
                  is_public: nil, is_trial: nil, google_analytics: nil, facebook_pixel: nil,
-                 google_tag_manager: nil, notifications: nil)
+                 google_tag_manager: nil, notifications: nil, are_uploads_public: nil)
 
     @redirect_after_submit_url = redirect_after_submit_url
     @show_typeform_branding = show_typeform_branding


### PR DESCRIPTION
Yet again there are fields added to the API response which break the gem. Since you are using Ruby Keyword arguments you can't just add fields to your API without updating your gems